### PR TITLE
Fix Winget package identifier

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -9,5 +9,5 @@ jobs:
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:
-          identifier: nefarius.HidHide
+          identifier: ViGEm.HidHide
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Package is still stored in microsoft/winget-pkgs as ViGEm.HidHide. A new package could be submitted and users of the previous package migrated if the package identifier change is still needed; providing the updated version to users first.

The updated workflow shouldn't be executed for this release, as a fixed manifest has already been PR'd, see linked.

Related:
https://github.com/nefarius/HidHide/discussions/155
https://github.com/microsoft/winget-pkgs/pull/160057
https://github.com/microsoft/winget-pkgs/issues/160054