### PR TITLE
Added support for crash-causing ERROR_GEN_FAILURE on enumeration

### DIFF
--- a/HidHideCLI/src/HID.cpp
+++ b/HidHideCLI/src/HID.cpp
@@ -266,7 +266,8 @@ namespace
         auto const deviceObject{ CloseHandlePtr(::CreateFileW(symbolicLink.c_str(), GENERIC_READ, (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE), nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr), &::CloseHandle) };
         if (INVALID_HANDLE_VALUE == deviceObject.get())
         {
-            switch (::GetLastError())
+            const DWORD win32Error = ::GetLastError();
+            switch (win32Error)
             {
             case ERROR_ACCESS_DENIED:
                 // The device is opened exclusively and in use hence we can't interact with it
@@ -280,6 +281,9 @@ namespace
                 return (result);
             case ERROR_PATH_NOT_FOUND:
                 // The symbolic link could not be opened
+                return (result);
+            case ERROR_GEN_FAILURE:
+                // The device is in a non-responsive state
                 return (result);
             default:
                 THROW_WIN32_LAST_ERROR;

--- a/Setup/nefarius_HidHide_Updater.exe
+++ b/Setup/nefarius_HidHide_Updater.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:128ceb8c6b5e9f32261b55ba904234ed52e26d03c9b92422cd2cf8b101bc1a88
-size 2347432
+oid sha256:e4123488e49fc8fcf74f6036180733bcbeb28ad08e3f0ae401b286aea4cdce18
+size 2367400


### PR DESCRIPTION
Reported by Kimonoha on Discord.

Some devices can fail with `ERROR_GEN_FAILURE` when being enumerated, this change ignores this error.

Also updated software updater agent to latest version.