### PR TITLE
Some memory management fixes in the driver

### DIFF
--- a/HidHide/HidHide.vcxproj
+++ b/HidHide/HidHide.vcxproj
@@ -103,7 +103,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)src;$(IntDir);$(KMDF_INC_PATH)$(KMDF_VER_PATH)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PreprocessorDefinitions>_WIN64;_AMD64_;AMD64;NDEBUG;_NO_CRT_STDIO_INLINE;%(BldParameters);ProjectDirLength=%(ProjectDirLength);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>POOL_NX_OPTIN=1;_WIN64;_AMD64_;AMD64;NDEBUG;_NO_CRT_STDIO_INLINE;%(BldParameters);ProjectDirLength=%(ProjectDirLength);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
@@ -124,7 +124,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)src;$(IntDir);$(KMDF_INC_PATH)$(KMDF_VER_PATH)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PreprocessorDefinitions>_WIN64;_AMD64_;AMD64;NDEBUG;_NO_CRT_STDIO_INLINE;%(BldParameters);ProjectDirLength=%(ProjectDirLength);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>POOL_NX_OPTIN=1;_WIN64;_AMD64_;AMD64;NDEBUG;_NO_CRT_STDIO_INLINE;%(BldParameters);ProjectDirLength=%(ProjectDirLength);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>
@@ -145,7 +145,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)src;$(IntDir);$(KMDF_INC_PATH)$(KMDF_VER_PATH)\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PreprocessorDefinitions>_WIN64;_AMD64_;AMD64;NDEBUG;_NO_CRT_STDIO_INLINE;%(BldParameters);ProjectDirLength=%(ProjectDirLength);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>POOL_NX_OPTIN=1;_WIN64;_AMD64_;AMD64;NDEBUG;_NO_CRT_STDIO_INLINE;%(BldParameters);ProjectDirLength=%(ProjectDirLength);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
     <Link>

--- a/HidHide/src/Config.c
+++ b/HidHide/src/Config.c
@@ -28,7 +28,7 @@ typedef struct _PROCESSIDTREE
 PPROCESSIDTREE s_ProcessIdToFullLoadImageNameMappingTree = NULL;
 
 // Unique memory pool tag for the tree
-#define CONFIG_TAG '1gaT'
+#define CONFIG_TAG 'fCHH'
 
 // Insert the new node in the tree
 // On success, the tree takes ownership of the node and its cleanup
@@ -174,7 +174,9 @@ _Use_decl_annotations_
     NTSTATUS       ntstatus;
 
     // Bail out when memory allocation failed
-    temp = ExAllocatePoolZero(NonPagedPool, sizeof(*temp), CONFIG_TAG);
+#pragma warning(disable: 4996)
+    temp = ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(*temp), CONFIG_TAG);
+#pragma warning(default: 4996)
     if (NULL == temp) LOG_AND_RETURN_NTSTATUS(L"ExAllocatePoolWithTag", STATUS_NO_MEMORY);
 
     // Ensure that the left and right pointers are NULL and the string is terminated
@@ -705,7 +707,7 @@ NTSTATUS HidHideDeviceInstancePath(WDFDEVICE wdfDevice, WDFSTRING* deviceInstanc
     WDF_DEVICE_PROPERTY_DATA_INIT(&wdfDevicePropertyData, &DEVPKEY_Device_InstanceId);
     WDF_OBJECT_ATTRIBUTES_INIT(&wdfObjectAttributes);
     wdfObjectAttributes.ParentObject = wdfDevice;
-    ntstatus = WdfDeviceAllocAndQueryPropertyEx(wdfDevice, &wdfDevicePropertyData, NonPagedPool, &wdfObjectAttributes, &wdfMemory, &devPropType);
+    ntstatus = WdfDeviceAllocAndQueryPropertyEx(wdfDevice, &wdfDevicePropertyData, NonPagedPoolNx, &wdfObjectAttributes, &wdfMemory, &devPropType);
     if (!NT_SUCCESS(ntstatus)) LOG_AND_RETURN_NTSTATUS(L"WdfDeviceAllocAndQueryPropertyEx", ntstatus);
     if (DEVPROP_TYPE_STRING != devPropType)
     {

--- a/HidHide/src/Logic.c
+++ b/HidHide/src/Logic.c
@@ -193,7 +193,7 @@ VOID OnDeviceFileCreate(WDFDEVICE wdfDevice, WDFREQUEST wdfRequest, WDFFILEOBJEC
         // Trace the first-time the device instance path is challenged, in support of the message above
         if (!cacheHit)
         {
-            ntstatus = WdfMemoryCreate(WDF_NO_OBJECT_ATTRIBUTES, NonPagedPool, LOGIC_TAG, sizeof(WCHAR) * ((size_t)deviceInstancePath.Length + 1), &wdfMemory, &buffer);
+            ntstatus = WdfMemoryCreate(WDF_NO_OBJECT_ATTRIBUTES, NonPagedPoolNx, LOGIC_TAG, sizeof(WCHAR) * ((size_t)deviceInstancePath.Length + 1), &wdfMemory, &buffer);
             if (NT_SUCCESS(ntstatus)) ntstatus = RtlStringCchCopyUnicodeStringEx(buffer, ((size_t)deviceInstancePath.Length + 1), &deviceInstancePath, NULL, NULL, STRSAFE_NO_TRUNCATION);
             if (NT_SUCCESS(ntstatus)) TRACE_ALWAYS(buffer);
             WdfObjectDelete(wdfMemory);

--- a/HidHide/src/Logic.c
+++ b/HidHide/src/Logic.c
@@ -9,7 +9,7 @@
 #include "Logging.h"
 
 // Unique memory pool tag for buffers
-#define LOGIC_TAG '2gaT'
+#define LOGIC_TAG 'oLHH'
 
 // The control device is created first and should be deleted last after having release the driver resources
 // Releasing the control device is required else the driver will never unload

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.5.{build}.0
+version: 1.6.{build}.0
 build_cloud: WIN-LKR467JS4GL
 image: Windows
 configuration: Release


### PR DESCRIPTION
- Added missing `POOL_NX_OPTIN=1`
- Fixed pool tag value `CONFIG_TAG`
- Replaced unnecessary use of `ExAllocatePoolZero` with `ExAllocatePoolWithTag`
- Replaced uses of `NonPagedPool` with `NonPagedPoolNx`