### PR TITLE
Add process-lifetime (session) blacklist via IOCTL_ADD_SESSION_BLACKLIST

### DIFF
--- a/HidHide/src/Logic.c
+++ b/HidHide/src/Logic.c
@@ -595,34 +595,35 @@ NTSTATUS OnControlDeviceIoAddSessionBlacklist(WDFDEVICE wdfControlDevice, WDFQUE
     UNREFERENCED_PARAMETER(wdfQueue);
     UNREFERENCED_PARAMETER(ioControlCode);
 
-    LPWSTR   buffer;
-    NTSTATUS ntstatus;
-    HANDLE   callerPid;
+    LPWSTR                  buffer;
+    NTSTATUS                ntstatus;
+    HANDLE                  callerPid;
+    size_t                  totalChars;
+    LIST_ENTRY              localHead;
+    LPWSTR                  current;
+    PCONTROL_DEVICE_CONTEXT pControlDeviceContext;
 
     if (0 != outputBufferLength) LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
     // MULTI_SZ must be at least two null WCHAR terminators (4 bytes) and a whole number of WCHARs
-    if (inputBufferLength < (2 * sizeof(WCHAR)))        LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
-    if (0 != (inputBufferLength % sizeof(WCHAR)))       LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
+    if (inputBufferLength < (2 * sizeof(WCHAR)))  LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
+    if (0 != (inputBufferLength % sizeof(WCHAR))) LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
 
     ntstatus = WdfRequestRetrieveInputBuffer(wdfRequest, inputBufferLength, &buffer, NULL);
     if (!NT_SUCCESS(ntstatus)) LOG_AND_RETURN_NTSTATUS(L"WdfRequestRetrieveInputBuffer", ntstatus);
 
     // Verify the buffer ends with a double-NUL as required by MULTI_SZ format
-    size_t totalChars = inputBufferLength / sizeof(WCHAR);
+    totalChars = inputBufferLength / sizeof(WCHAR);
     if ((buffer[totalChars - 1] != L'\0') || (buffer[totalChars - 2] != L'\0'))
         LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
 
-    callerPid = PsGetCurrentProcessId();
-
-    PCONTROL_DEVICE_CONTEXT pControlDeviceContext = ControlDeviceGetContext(s_wdfControlDevice);
+    callerPid             = PsGetCurrentProcessId();
+    pControlDeviceContext = ControlDeviceGetContext(s_wdfControlDevice);
 
     // Build all entries into a local list before touching the global list.
     // This makes the operation atomic: either all entries are committed or none are.
-    LIST_ENTRY localHead;
     InitializeListHead(&localHead);
     ntstatus = STATUS_SUCCESS;
-
-    LPWSTR current = buffer;
+    current  = buffer;
 
     while ((size_t)(current - buffer) < totalChars && *current != L'\0')
     {
@@ -704,21 +705,27 @@ NTSTATUS OnControlDeviceIoClearSessionBlacklist(WDFDEVICE wdfControlDevice, WDFQ
     return (STATUS_SUCCESS);
 }
 
+_Use_decl_annotations_
 VOID SessionBlacklistCleanupForPid(HANDLE processId)
 {
     TRACE_PERFORMANCE(L"");
 
+    PCONTROL_DEVICE_CONTEXT  pControlDeviceContext;
+    PLIST_ENTRY              entry;
+    PSESSION_BLACKLIST_ENTRY sbe;
+    PLIST_ENTRY              next;
+
     if (NULL == s_wdfControlDevice) return;
 
-    PCONTROL_DEVICE_CONTEXT pControlDeviceContext = ControlDeviceGetContext(s_wdfControlDevice);
+    pControlDeviceContext = ControlDeviceGetContext(s_wdfControlDevice);
 
     WdfWaitLockAcquire(s_criticalSectionLock, NULL);
 
-    PLIST_ENTRY entry = pControlDeviceContext->sessionBlacklistHead.Flink;
+    entry = pControlDeviceContext->sessionBlacklistHead.Flink;
     while (entry != &pControlDeviceContext->sessionBlacklistHead)
     {
-        PSESSION_BLACKLIST_ENTRY sbe = CONTAINING_RECORD(entry, SESSION_BLACKLIST_ENTRY, listEntry);
-        PLIST_ENTRY next = entry->Flink;
+        sbe  = CONTAINING_RECORD(entry, SESSION_BLACKLIST_ENTRY, listEntry);
+        next = entry->Flink;
 
         if (sbe->ownerPid == processId)
         {
@@ -788,10 +795,12 @@ BOOLEAN Blacklisted(PUNICODE_STRING deviceInstancePath, ULONG sessionId)
 {
     TRACE_PERFORMANCE(L"");
 
-    PCONTROL_DEVICE_CONTEXT pControlDeviceContext;
-    UNICODE_STRING          inputFilter;
-    UNICODE_STRING          blacklistedDeviceInstancePath;
-    ULONG                   jailSessionId;
+    PCONTROL_DEVICE_CONTEXT  pControlDeviceContext;
+    UNICODE_STRING           inputFilter;
+    UNICODE_STRING           blacklistedDeviceInstancePath;
+    ULONG                    jailSessionId;
+    PLIST_ENTRY              entry;
+    PSESSION_BLACKLIST_ENTRY sbe;
 
     WdfWaitLockAcquire(s_criticalSectionLock, NULL);
     pControlDeviceContext = ControlDeviceGetContext(s_wdfControlDevice);
@@ -810,10 +819,10 @@ BOOLEAN Blacklisted(PUNICODE_STRING deviceInstancePath, ULONG sessionId)
     }
 
     // Check session (process-lifetime) blacklist
-    PLIST_ENTRY entry = pControlDeviceContext->sessionBlacklistHead.Flink;
+    entry = pControlDeviceContext->sessionBlacklistHead.Flink;
     while (entry != &pControlDeviceContext->sessionBlacklistHead)
     {
-        PSESSION_BLACKLIST_ENTRY sbe = CONTAINING_RECORD(entry, SESSION_BLACKLIST_ENTRY, listEntry);
+        sbe = CONTAINING_RECORD(entry, SESSION_BLACKLIST_ENTRY, listEntry);
         WdfStringGetUnicodeString(sbe->deviceInstancePath, &inputFilter);
 
         if (0 == RtlCompareUnicodeString(&inputFilter, deviceInstancePath, TRUE))

--- a/HidHide/src/Logic.c
+++ b/HidHide/src/Logic.c
@@ -71,9 +71,23 @@ _Use_decl_annotations_
 VOID OnControlDeviceContextCleanup(WDFOBJECT wdfControlDeviceObject)
 {
     TRACE_ALWAYS(L"");
-    UNREFERENCED_PARAMETER(wdfControlDeviceObject);
 
-    // No specific action needed for this device driver but we like the tracing for tracing purposes
+    PCONTROL_DEVICE_CONTEXT pControlDeviceContext = ControlDeviceGetContext(wdfControlDeviceObject);
+
+    // Drain any remaining session blacklist entries left over at driver unload.
+    // s_criticalSectionLock is a child of the control device and is still live during its cleanup callback.
+    WdfWaitLockAcquire(s_criticalSectionLock, NULL);
+    PLIST_ENTRY entry = pControlDeviceContext->sessionBlacklistHead.Flink;
+    while (entry != &pControlDeviceContext->sessionBlacklistHead)
+    {
+        PSESSION_BLACKLIST_ENTRY sbe = CONTAINING_RECORD(entry, SESSION_BLACKLIST_ENTRY, listEntry);
+        PLIST_ENTRY next = entry->Flink;
+        RemoveEntryList(entry);
+        WdfObjectDelete(sbe->deviceInstancePath);
+        ExFreePoolWithTag(sbe, 'lBSH');
+        entry = next;
+    }
+    WdfWaitLockRelease(s_criticalSectionLock);
 }
 
 _Use_decl_annotations_
@@ -594,30 +608,72 @@ NTSTATUS OnControlDeviceIoAddSessionBlacklist(WDFDEVICE wdfControlDevice, WDFQUE
 
     PCONTROL_DEVICE_CONTEXT pControlDeviceContext = ControlDeviceGetContext(s_wdfControlDevice);
 
-    // Walk the multi-string input and create a session entry per device instance path
+    // Build all entries into a local list before touching the global list.
+    // This makes the operation atomic: either all entries are committed or none are.
+    LIST_ENTRY localHead;
+    InitializeListHead(&localHead);
+    ntstatus = STATUS_SUCCESS;
+
+    size_t totalChars = inputBufferLength / sizeof(WCHAR);
     LPWSTR current = buffer;
-    while (*current != L'\0')
+
+    while ((size_t)(current - buffer) < totalChars && *current != L'\0')
     {
+        size_t remaining = totalChars - (size_t)(current - buffer);
+        size_t len = wcsnlen(current, remaining);
+        if (len >= remaining)
+        {
+            // Malformed multi-string: no null terminator within buffer bounds
+            ntstatus = STATUS_INVALID_PARAMETER;
+            break;
+        }
+
         UNICODE_STRING path;
-        RtlInitUnicodeString(&path, current);
+        path.Buffer = current;
+        path.Length = (USHORT)(len * sizeof(WCHAR));
+        path.MaximumLength = path.Length + sizeof(WCHAR);
 
         PSESSION_BLACKLIST_ENTRY entry = (PSESSION_BLACKLIST_ENTRY)ExAllocatePoolWithTag(NonPagedPool, sizeof(SESSION_BLACKLIST_ENTRY), 'lBSH');
-        if (NULL == entry) LOG_AND_RETURN_NTSTATUS(L"ExAllocatePoolWithTag", STATUS_INSUFFICIENT_RESOURCES);
+        if (NULL == entry)
+        {
+            ntstatus = STATUS_INSUFFICIENT_RESOURCES;
+            break;
+        }
 
         ntstatus = WdfStringCreate(&path, WDF_NO_OBJECT_ATTRIBUTES, &entry->deviceInstancePath);
         if (!NT_SUCCESS(ntstatus))
         {
             ExFreePoolWithTag(entry, 'lBSH');
-            LOG_AND_RETURN_NTSTATUS(L"WdfStringCreate", ntstatus);
+            break;
         }
 
         entry->ownerPid = callerPid;
+        InsertTailList(&localHead, &entry->listEntry);
 
+        current += len + 1;
+    }
+
+    if (!NT_SUCCESS(ntstatus))
+    {
+        // Free all locally built entries — nothing has been committed to the global list
+        PLIST_ENTRY le = localHead.Flink;
+        while (le != &localHead)
+        {
+            PSESSION_BLACKLIST_ENTRY sbe = CONTAINING_RECORD(le, SESSION_BLACKLIST_ENTRY, listEntry);
+            le = le->Flink;
+            RemoveEntryList(&sbe->listEntry);
+            WdfObjectDelete(sbe->deviceInstancePath);
+            ExFreePoolWithTag(sbe, 'lBSH');
+        }
+        LOG_AND_RETURN_NTSTATUS(L"OnControlDeviceIoAddSessionBlacklist", ntstatus);
+    }
+
+    // Splice local list into global list under lock — O(1), no allocations inside critical section
+    if (!IsListEmpty(&localHead))
+    {
         WdfWaitLockAcquire(s_criticalSectionLock, NULL);
-        InsertTailList(&pControlDeviceContext->sessionBlacklistHead, &entry->listEntry);
+        AppendTailList(&pControlDeviceContext->sessionBlacklistHead, &localHead);
         WdfWaitLockRelease(s_criticalSectionLock);
-
-        current += wcslen(current) + 1;
     }
 
     WdfRequestCompleteWithInformation(wdfRequest, STATUS_SUCCESS, inputBufferLength);

--- a/HidHide/src/Logic.c
+++ b/HidHide/src/Logic.c
@@ -75,8 +75,9 @@ VOID OnControlDeviceContextCleanup(WDFOBJECT wdfControlDeviceObject)
     PCONTROL_DEVICE_CONTEXT pControlDeviceContext = ControlDeviceGetContext(wdfControlDeviceObject);
 
     // Drain any remaining session blacklist entries left over at driver unload.
-    // s_criticalSectionLock is a child of the control device and is still live during its cleanup callback.
-    WdfWaitLockAcquire(s_criticalSectionLock, NULL);
+    // s_criticalSectionLock is a child of the control device and is still live during its cleanup
+    // callback, but guard against the case where WdfWaitLockCreate failed and left it NULL.
+    if (NULL != s_criticalSectionLock) WdfWaitLockAcquire(s_criticalSectionLock, NULL);
     PLIST_ENTRY entry = pControlDeviceContext->sessionBlacklistHead.Flink;
     while (entry != &pControlDeviceContext->sessionBlacklistHead)
     {
@@ -87,7 +88,7 @@ VOID OnControlDeviceContextCleanup(WDFOBJECT wdfControlDeviceObject)
         ExFreePoolWithTag(sbe, 'lBSH');
         entry = next;
     }
-    WdfWaitLockRelease(s_criticalSectionLock);
+    if (NULL != s_criticalSectionLock) WdfWaitLockRelease(s_criticalSectionLock);
 }
 
 _Use_decl_annotations_
@@ -599,10 +600,17 @@ NTSTATUS OnControlDeviceIoAddSessionBlacklist(WDFDEVICE wdfControlDevice, WDFQUE
     HANDLE   callerPid;
 
     if (0 != outputBufferLength) LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
-    if (0 == inputBufferLength)  LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
+    // MULTI_SZ must be at least two null WCHAR terminators (4 bytes) and a whole number of WCHARs
+    if (inputBufferLength < (2 * sizeof(WCHAR)))        LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
+    if (0 != (inputBufferLength % sizeof(WCHAR)))       LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
 
     ntstatus = WdfRequestRetrieveInputBuffer(wdfRequest, inputBufferLength, &buffer, NULL);
     if (!NT_SUCCESS(ntstatus)) LOG_AND_RETURN_NTSTATUS(L"WdfRequestRetrieveInputBuffer", ntstatus);
+
+    // Verify the buffer ends with a double-NUL as required by MULTI_SZ format
+    size_t totalChars = inputBufferLength / sizeof(WCHAR);
+    if ((buffer[totalChars - 1] != L'\0') || (buffer[totalChars - 2] != L'\0'))
+        LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
 
     callerPid = PsGetCurrentProcessId();
 
@@ -614,7 +622,6 @@ NTSTATUS OnControlDeviceIoAddSessionBlacklist(WDFDEVICE wdfControlDevice, WDFQUE
     InitializeListHead(&localHead);
     ntstatus = STATUS_SUCCESS;
 
-    size_t totalChars = inputBufferLength / sizeof(WCHAR);
     LPWSTR current = buffer;
 
     while ((size_t)(current - buffer) < totalChars && *current != L'\0')
@@ -689,7 +696,7 @@ NTSTATUS OnControlDeviceIoClearSessionBlacklist(WDFDEVICE wdfControlDevice, WDFQ
     UNREFERENCED_PARAMETER(inputBufferLength);
     UNREFERENCED_PARAMETER(ioControlCode);
 
-    if (0 != outputBufferLength) LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
+    if ((0 != outputBufferLength) || (0 != inputBufferLength)) LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
 
     SessionBlacklistCleanupForPid(PsGetCurrentProcessId());
 

--- a/HidHide/src/Logic.c
+++ b/HidHide/src/Logic.c
@@ -87,6 +87,7 @@ VOID OnSystemProcessChange(HANDLE parentId, HANDLE processId, BOOLEAN create)
     if (FALSE == create)
     {
         HidHideProcessIdUnregister(s_criticalSectionLock, processId);
+        SessionBlacklistCleanupForPid(processId);
     }
 }
 
@@ -261,6 +262,7 @@ NTSTATUS OnControlDeviceCreate(WDFDEVICE wdfControlDevice)
     pControlDeviceContext = ControlDeviceGetContext(wdfControlDevice);
     pControlDeviceContext->numberOfDevicesCreated = 0;
     pControlDeviceContext->shutdownPending = FALSE;
+    InitializeListHead(&pControlDeviceContext->sessionBlacklistHead);
 
     // Query the multi-string property containing the white-listed full image names
     DECLARE_CONST_UNICODE_STRING(whitelistedFullImageNames, DRIVER_PROPERTY_WHITELISTED_FULL_IMAGE_NAMES);
@@ -340,6 +342,12 @@ NTSTATUS OnControlDeviceIoDeviceControl(WDFDEVICE wdfControlDevice, WDFQUEUE wdf
         break;
     case IOCTL_SET_WLINVERSE:
         return (OnControlDeviceIoSetInverse(wdfControlDevice, wdfQueue, wdfRequest, outputBufferLength, inputBufferLength, ioControlCode));
+        break;
+    case IOCTL_ADD_SESSION_BLACKLIST:
+        return (OnControlDeviceIoAddSessionBlacklist(wdfControlDevice, wdfQueue, wdfRequest, outputBufferLength, inputBufferLength, ioControlCode));
+        break;
+    case IOCTL_CLR_SESSION_BLACKLIST:
+        return (OnControlDeviceIoClearSessionBlacklist(wdfControlDevice, wdfQueue, wdfRequest, outputBufferLength, inputBufferLength, ioControlCode));
         break;
     default:
         LOG_AND_RETURN_NTSTATUS(L"OnControlDeviceIoDeviceControl", STATUS_INVALID_PARAMETER);
@@ -565,6 +573,104 @@ NTSTATUS OnControlDeviceIoSetInverse(WDFDEVICE wdfControlDevice, WDFQUEUE wdfQue
 }
 
 _Use_decl_annotations_
+NTSTATUS OnControlDeviceIoAddSessionBlacklist(WDFDEVICE wdfControlDevice, WDFQUEUE wdfQueue, WDFREQUEST wdfRequest, size_t outputBufferLength, size_t inputBufferLength, ULONG ioControlCode)
+{
+    TRACE_ALWAYS(L"");
+    UNREFERENCED_PARAMETER(wdfControlDevice);
+    UNREFERENCED_PARAMETER(wdfQueue);
+    UNREFERENCED_PARAMETER(ioControlCode);
+
+    LPWSTR   buffer;
+    NTSTATUS ntstatus;
+    HANDLE   callerPid;
+
+    if (0 != outputBufferLength) LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
+    if (0 == inputBufferLength)  LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
+
+    ntstatus = WdfRequestRetrieveInputBuffer(wdfRequest, inputBufferLength, &buffer, NULL);
+    if (!NT_SUCCESS(ntstatus)) LOG_AND_RETURN_NTSTATUS(L"WdfRequestRetrieveInputBuffer", ntstatus);
+
+    callerPid = PsGetCurrentProcessId();
+
+    PCONTROL_DEVICE_CONTEXT pControlDeviceContext = ControlDeviceGetContext(s_wdfControlDevice);
+
+    // Walk the multi-string input and create a session entry per device instance path
+    LPWSTR current = buffer;
+    while (*current != L'\0')
+    {
+        UNICODE_STRING path;
+        RtlInitUnicodeString(&path, current);
+
+        PSESSION_BLACKLIST_ENTRY entry = (PSESSION_BLACKLIST_ENTRY)ExAllocatePoolWithTag(NonPagedPool, sizeof(SESSION_BLACKLIST_ENTRY), 'lBSH');
+        if (NULL == entry) LOG_AND_RETURN_NTSTATUS(L"ExAllocatePoolWithTag", STATUS_INSUFFICIENT_RESOURCES);
+
+        ntstatus = WdfStringCreate(&path, WDF_NO_OBJECT_ATTRIBUTES, &entry->deviceInstancePath);
+        if (!NT_SUCCESS(ntstatus))
+        {
+            ExFreePoolWithTag(entry, 'lBSH');
+            LOG_AND_RETURN_NTSTATUS(L"WdfStringCreate", ntstatus);
+        }
+
+        entry->ownerPid = callerPid;
+
+        WdfWaitLockAcquire(s_criticalSectionLock, NULL);
+        InsertTailList(&pControlDeviceContext->sessionBlacklistHead, &entry->listEntry);
+        WdfWaitLockRelease(s_criticalSectionLock);
+
+        current += wcslen(current) + 1;
+    }
+
+    WdfRequestCompleteWithInformation(wdfRequest, STATUS_SUCCESS, inputBufferLength);
+    return (STATUS_SUCCESS);
+}
+
+_Use_decl_annotations_
+NTSTATUS OnControlDeviceIoClearSessionBlacklist(WDFDEVICE wdfControlDevice, WDFQUEUE wdfQueue, WDFREQUEST wdfRequest, size_t outputBufferLength, size_t inputBufferLength, ULONG ioControlCode)
+{
+    TRACE_ALWAYS(L"");
+    UNREFERENCED_PARAMETER(wdfControlDevice);
+    UNREFERENCED_PARAMETER(wdfQueue);
+    UNREFERENCED_PARAMETER(inputBufferLength);
+    UNREFERENCED_PARAMETER(ioControlCode);
+
+    if (0 != outputBufferLength) LOG_AND_RETURN_NTSTATUS(L"Validation", STATUS_INVALID_PARAMETER);
+
+    SessionBlacklistCleanupForPid(PsGetCurrentProcessId());
+
+    WdfRequestCompleteWithInformation(wdfRequest, STATUS_SUCCESS, 0);
+    return (STATUS_SUCCESS);
+}
+
+VOID SessionBlacklistCleanupForPid(HANDLE processId)
+{
+    TRACE_PERFORMANCE(L"");
+
+    if (NULL == s_wdfControlDevice) return;
+
+    PCONTROL_DEVICE_CONTEXT pControlDeviceContext = ControlDeviceGetContext(s_wdfControlDevice);
+
+    WdfWaitLockAcquire(s_criticalSectionLock, NULL);
+
+    PLIST_ENTRY entry = pControlDeviceContext->sessionBlacklistHead.Flink;
+    while (entry != &pControlDeviceContext->sessionBlacklistHead)
+    {
+        PSESSION_BLACKLIST_ENTRY sbe = CONTAINING_RECORD(entry, SESSION_BLACKLIST_ENTRY, listEntry);
+        PLIST_ENTRY next = entry->Flink;
+
+        if (sbe->ownerPid == processId)
+        {
+            RemoveEntryList(entry);
+            WdfObjectDelete(sbe->deviceInstancePath);
+            ExFreePoolWithTag(sbe, 'lBSH');
+        }
+
+        entry = next;
+    }
+
+    WdfWaitLockRelease(s_criticalSectionLock);
+}
+
+_Use_decl_annotations_
 BOOLEAN Whitelisted(HANDLE processId, BOOLEAN* cacheHit)
 {
     TRACE_PERFORMANCE(L"");
@@ -626,6 +732,8 @@ BOOLEAN Blacklisted(PUNICODE_STRING deviceInstancePath, ULONG sessionId)
 
     WdfWaitLockAcquire(s_criticalSectionLock, NULL);
     pControlDeviceContext = ControlDeviceGetContext(s_wdfControlDevice);
+
+    // Check persistent blacklist
     for (ULONG index1 = 0, size1 = WdfCollectionGetCount(pControlDeviceContext->blacklistedDeviceInstancePaths); (index1 < size1); index1++)
     {
         WdfStringGetUnicodeString(WdfCollectionGetItem(pControlDeviceContext->blacklistedDeviceInstancePaths, index1), &inputFilter); // PASSIVE_LEVEL
@@ -637,6 +745,23 @@ BOOLEAN Blacklisted(PUNICODE_STRING deviceInstancePath, ULONG sessionId)
             return (sessionId != 0 && jailSessionId != 0 && sessionId == jailSessionId ? FALSE : TRUE);
         }
     }
+
+    // Check session (process-lifetime) blacklist
+    PLIST_ENTRY entry = pControlDeviceContext->sessionBlacklistHead.Flink;
+    while (entry != &pControlDeviceContext->sessionBlacklistHead)
+    {
+        PSESSION_BLACKLIST_ENTRY sbe = CONTAINING_RECORD(entry, SESSION_BLACKLIST_ENTRY, listEntry);
+        WdfStringGetUnicodeString(sbe->deviceInstancePath, &inputFilter);
+
+        if (0 == RtlCompareUnicodeString(&inputFilter, deviceInstancePath, TRUE))
+        {
+            WdfWaitLockRelease(s_criticalSectionLock);
+            return (TRUE);
+        }
+
+        entry = entry->Flink;
+    }
+
     WdfWaitLockRelease(s_criticalSectionLock);
 
     return (FALSE);

--- a/HidHide/src/Logic.h
+++ b/HidHide/src/Logic.h
@@ -24,8 +24,10 @@ ULONG PsGetProcessSessionId(PEPROCESS process);
 #define IOCTL_SET_BLACKLIST CTL_CODE(IoControlDeviceType, 2051, METHOD_BUFFERED, FILE_READ_DATA)
 #define IOCTL_GET_ACTIVE    CTL_CODE(IoControlDeviceType, 2052, METHOD_BUFFERED, FILE_READ_DATA)
 #define IOCTL_SET_ACTIVE    CTL_CODE(IoControlDeviceType, 2053, METHOD_BUFFERED, FILE_READ_DATA)
-#define IOCTL_GET_WLINVERSE CTL_CODE(IoControlDeviceType, 2054, METHOD_BUFFERED, FILE_READ_DATA)
-#define IOCTL_SET_WLINVERSE CTL_CODE(IoControlDeviceType, 2055, METHOD_BUFFERED, FILE_READ_DATA)
+#define IOCTL_GET_WLINVERSE          CTL_CODE(IoControlDeviceType, 2054, METHOD_BUFFERED, FILE_READ_DATA)
+#define IOCTL_SET_WLINVERSE          CTL_CODE(IoControlDeviceType, 2055, METHOD_BUFFERED, FILE_READ_DATA)
+#define IOCTL_ADD_SESSION_BLACKLIST  CTL_CODE(IoControlDeviceType, 2056, METHOD_BUFFERED, FILE_READ_DATA)
+#define IOCTL_CLR_SESSION_BLACKLIST  CTL_CODE(IoControlDeviceType, 2057, METHOD_BUFFERED, FILE_READ_DATA)
 
 // {0C320FF7-BD9B-42B6-BDAF-49FEB9C91649}
 DEFINE_GUID(HidHideInterfaceGuid, 0xc320ff7, 0xbd9b, 0x42b6, 0xbd, 0xaf, 0x49, 0xfe, 0xb9, 0xc9, 0x16, 0x49);
@@ -55,10 +57,22 @@ typedef struct _CONTROL_DEVICE_CONTEXT
     // The whitelisted inverse (enabled) state
     BOOLEAN whitelistedInverse;
 
+    // Collection of SESSION_BLACKLIST_ENTRY structures for process-lifetime blacklist entries
+    // Entries are automatically removed when the registering process exits
+    LIST_ENTRY sessionBlacklistHead;
+
     // During a shutdown we may only delete the control device object after the last device is removed so keep track of the number of devices and shutdown state
     BOOLEAN shutdownPending;
     INT32 numberOfDevicesCreated;
 } CONTROL_DEVICE_CONTEXT, *PCONTROL_DEVICE_CONTEXT;
+
+// An entry in the process-lifetime (session) blacklist
+typedef struct _SESSION_BLACKLIST_ENTRY
+{
+    LIST_ENTRY  listEntry;
+    HANDLE      ownerPid;
+    WDFSTRING   deviceInstancePath;
+} SESSION_BLACKLIST_ENTRY, *PSESSION_BLACKLIST_ENTRY;
 
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(CONTROL_DEVICE_CONTEXT, ControlDeviceGetContext)
 
@@ -153,6 +167,22 @@ NTSTATUS OnControlDeviceIoGetInverse(_In_ WDFDEVICE wdfDevice, _In_ WDFQUEUE wdf
 _IRQL_requires_same_
 _IRQL_requires_max_(DISPATCH_LEVEL)
 NTSTATUS OnControlDeviceIoSetInverse(_In_ WDFDEVICE wdfDevice, _In_ WDFQUEUE wdfQueue, _In_ WDFREQUEST wdfRequest, _In_ size_t outputBufferLength, _In_ size_t inputBufferLength, _In_ ULONG ioControlCode);
+
+// Handle AddSessionBlacklist I/O request — adds device instance paths to a process-lifetime blacklist
+// Entries are automatically removed when the calling process exits (clean or crash)
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS OnControlDeviceIoAddSessionBlacklist(_In_ WDFDEVICE wdfDevice, _In_ WDFQUEUE wdfQueue, _In_ WDFREQUEST wdfRequest, _In_ size_t outputBufferLength, _In_ size_t inputBufferLength, _In_ ULONG ioControlCode);
+
+// Handle ClearSessionBlacklist I/O request — removes all session blacklist entries for the calling process
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+NTSTATUS OnControlDeviceIoClearSessionBlacklist(_In_ WDFDEVICE wdfDevice, _In_ WDFQUEUE wdfQueue, _In_ WDFREQUEST wdfRequest, _In_ size_t outputBufferLength, _In_ size_t inputBufferLength, _In_ ULONG ioControlCode);
+
+// Remove all session blacklist entries owned by the given process ID
+_IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID SessionBlacklistCleanupForPid(_In_ HANDLE processId);
 
 // Is the process id on the whitelist?
 // On a match, the cache-hit indicates if its the first time or not


### PR DESCRIPTION
## Summary

- Adds `IOCTL_ADD_SESSION_BLACKLIST` (code 2056) and `IOCTL_CLR_SESSION_BLACKLIST` (code 2057)
- Applications register device instance paths against their own process handle
- When the registering process exits — for **any** reason (clean exit, crash, `TerminateProcess`, task kill) — HidHide automatically removes those entries via the existing `OnSystemProcessChange` callback
- No watchdog process, no cleanup code required in the calling application

## Motivation

The current blacklist is persistent (registry-backed), which is correct for permanent rules. But applications that want **"hide this device while I'm running, release it when I exit"** currently have no clean primitive for this — they must implement watchdog processes to handle crash cleanup, which adds complexity and can still leave devices hidden if the watchdog itself fails.

Moving this responsibility into the kernel is the right design: `OnSystemProcessChange` already fires reliably on all process terminations, including unexpected ones.

## Use case

Input remappers like DS4Windows want to claim controllers exclusively for their session without permanently hiding them from other applications (Steam Input, OpenRGB, etc.). When the remapper exits, devices should become visible again automatically — no reboot, no manual HidHide Client interaction required.

This directly addresses several open requests:
- schmaldeo/DS4Windows#68 — auto-manage HidHide hiding when loading native vs virtual-controller profiles
- schmaldeo/DS4Windows#100 — DS4Windows managing HidHide config on behalf of the user
- nefarius/HidHide#21 (closed) — prior discussion on conditional/per-process filtering

## Changes

**`Logic.h`**
- New IOCTL codes `IOCTL_ADD_SESSION_BLACKLIST` / `IOCTL_CLR_SESSION_BLACKLIST`
- `SESSION_BLACKLIST_ENTRY` struct (owner PID + device instance path)
- `sessionBlacklistHead` (`LIST_ENTRY`) added to `CONTROL_DEVICE_CONTEXT`
- `SessionBlacklistCleanupForPid()` declaration
- `OnControlDeviceIoAddSessionBlacklist()` / `OnControlDeviceIoClearSessionBlacklist()` declarations

**`Logic.c`**
- `OnControlDeviceCreate`: initialises `sessionBlacklistHead`
- `OnSystemProcessChange`: calls `SessionBlacklistCleanupForPid()` on process exit
- `OnControlDeviceIoDeviceControl`: dispatch cases for new IOCTLs
- `OnControlDeviceIoAddSessionBlacklist`: walks MULTI_SZ input, allocates `SESSION_BLACKLIST_ENTRY` per path tagged with caller PID, builds into local list and splices atomically under lock
- `OnControlDeviceIoClearSessionBlacklist`: explicit early release for calling process
- `SessionBlacklistCleanupForPid`: walks session list under lock, removes and frees all entries for the given PID
- `OnControlDeviceContextCleanup`: drains remaining session entries on driver unload
- `Blacklisted`: checks session list after persistent list

## Testing

Verified logic flow manually. Kernel build environment required for full testing — happy to iterate on review feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session-based device blacklisting: dynamically control which devices are hidden for the current session
  * Automatic cleanup of blacklist entries when processes terminate
  * Enhanced granular control over per-session device visibility management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->