### PR TITLE
chore(watchdog): bump vcpkg registry baselines after audit

### DIFF
--- a/Watchdog/vcpkg-configuration.json
+++ b/Watchdog/vcpkg-configuration.json
@@ -1,16 +1,16 @@
 {
+  "default-registry": {
+    "kind": "builtin",
+    "baseline": "62efe42f53b1886a20cbeb22ee9a27736d20f149"
+  },
   "registries": [
     {
       "kind": "git",
+      "baseline": "7ba0e21dc3f4bdef654480e5060621b01a110ebf",
       "repository": "https://github.com/nefarius/nefarius-vcpkg-registry.git",
-      "baseline": "a49373c595ad9a64f9b7c935066c1cd59ee960b1",
       "packages": [
         "neflib"
       ]
     }
-  ],
-  "default-registry": {
-    "kind": "builtin",
-    "baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
-  }
+  ]
 }


### PR DESCRIPTION
Update builtin baseline (microsoft/vcpkg) and nefarius-vcpkg-registry baseline via vcpkg x-update-baseline. neflib resolves to port version 1.3.2 at the new registry baseline (was 1.1.1).

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated registry configurations to latest baselines for improved package compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->