### PR TITLE
Added ETW REST interface for diagnostics

### DIFF
--- a/Watchdog/App.cpp
+++ b/Watchdog/App.cpp
@@ -1,15 +1,8 @@
 #include "App.hpp"
+#include "DiagnosticsTraceHandler.hpp"
+
 #include <initguid.h>
 #include <devguid.h>
-#include <winevt.h>
-#include <evntrace.h>
-#include <tdh.h>
-#include <strsafe.h>
-
-#include <variant>
-#include <expected>
-#include <format>
-#include <iostream>
 
 #include <nefarius/neflib/MiscWinApi.hpp>
 #include <nefarius/neflib/ClassFilter.hpp>
@@ -24,21 +17,11 @@
 #include <Poco/TaskManager.h>
 
 #include <Poco/Net/HTTPServer.h>
-#include <Poco/Net/HTTPRequestHandler.h>
-#include <Poco/Net/HTTPRequestHandlerFactory.h>
-#include <Poco/Net/HTTPServerRequest.h>
-#include <Poco/Net/HTTPServerResponse.h>
 #include <Poco/Net/ServerSocket.h>
 #include <Poco/Net/SocketAddress.h>
 #include <Poco/Net/HTTPServerParams.h>
-#include <Poco/JSON/Object.h>
-#include <Poco/JSON/Stringifier.h>
-#include <Poco/Timestamp.h>
 
-using namespace Poco;
 using namespace Poco::Net;
-using namespace Poco::JSON;
-using namespace Poco::Util;
 
 
 // XnaComposite
@@ -172,66 +155,6 @@ public:
     }
 };
 
-//
-// REST API /api/etw/session handler
-// 
-class ETWRequestHandler : public HTTPRequestHandler
-{
-public:
-    void handleRequest(HTTPServerRequest& request, HTTPServerResponse& response) override
-    {
-        if (request.getURI() != "/api/etw/session")
-        {
-            response.setStatus(HTTPResponse::HTTP_NOT_FOUND);
-            response.send();
-            return;
-        }
-
-        const auto& method = request.getMethod();
-
-        // get session details
-        if (method == HTTPRequest::HTTP_GET)
-        {
-        }
-        // start/create session
-        else if (method == HTTPRequest::HTTP_POST)
-        {
-        }
-        // stop/remove session
-        else if (method == HTTPRequest::HTTP_DELETE)
-        {
-        }
-        // unsupported
-        else
-        {
-            response.setStatus(HTTPResponse::HTTP_METHOD_NOT_ALLOWED);
-            response.send();
-            return;
-        }
-
-        response.setContentType("application/json");
-        response.setStatus(HTTPResponse::HTTP_OK);
-
-        // Create a JSON response
-        Object::Ptr jsonResponse = new Object();
-        jsonResponse->set("message", "Hello from POCO HTTP Server");
-        jsonResponse->set("timestamp", Timestamp().epochTime());
-
-        // Send the JSON response
-        std::ostream& out = response.send();
-        Stringifier::stringify(jsonResponse, out);
-    }
-};
-
-class ETWRequestHandlerFactory : public HTTPRequestHandlerFactory
-{
-public:
-    HTTPRequestHandler* createRequestHandler(const HTTPServerRequest& request) override
-    {
-        return new ETWRequestHandler;
-    }
-};
-
 class WebServerTask : public Poco::Task
 {
     bool _isInteractive;
@@ -249,7 +172,7 @@ public:
                                 ? spdlog::get("console")
                                 : spdlog::get("eventlog");
 
-        logger->info("Starting web server background thread");
+        logger->info("Starting diagnostics HTTP server on http://127.0.0.1:34501/");
 
         SocketAddress sa("127.0.0.1", 34501);
         ServerSocket serverSocket(sa);
@@ -257,7 +180,7 @@ public:
         params->setMaxQueued(100);
         params->setMaxThreads(4);
 
-        HTTPServer server(new ETWRequestHandlerFactory(), serverSocket, params);
+        HTTPServer server(new DiagnosticsHttpHandlerFactory(), serverSocket, params);
         server.start();
 
         logger->info("Started web server");
@@ -315,8 +238,7 @@ int App::main(const std::vector<std::string>& args)
         Poco::TaskManager tm;
         // filter driver watchdog
         tm.start(new WatchdogTask("HidHideWatchdog", this->isInteractive()));
-#if defined(EXPERIMENTAL)
-        // ETW session web server
+#if defined(HIDHIDE_WATCHDOG_HTTP)
         tm.start(new WebServerTask("HidHideWebServer", this->isInteractive()));
 #endif
         waitForTerminationRequest();

--- a/Watchdog/App.cpp
+++ b/Watchdog/App.cpp
@@ -1,6 +1,9 @@
 #include "App.hpp"
 #include "NefLibIncludes.hpp"
+
+#if defined(HIDHIDE_WATCHDOG_HTTP)
 #include "DiagnosticsTraceHandler.hpp"
+#endif
 
 #pragma warning(disable: 26800)
 #include <spdlog/spdlog.h>
@@ -11,12 +14,15 @@
 #include <Poco/Task.h>
 #include <Poco/TaskManager.h>
 
+#if defined(HIDHIDE_WATCHDOG_HTTP)
 #include <Poco/Net/HTTPServer.h>
 #include <Poco/Net/ServerSocket.h>
 #include <Poco/Net/SocketAddress.h>
 #include <Poco/Net/HTTPServerParams.h>
 
 using namespace Poco::Net;
+
+#endif
 
 
 // XnaComposite
@@ -150,6 +156,7 @@ public:
     }
 };
 
+#if defined(HIDHIDE_WATCHDOG_HTTP)
 class WebServerTask : public Poco::Task
 {
     bool _isInteractive;
@@ -192,6 +199,7 @@ public:
         logger->info("Stopping web server background thread");
     }
 };
+#endif
 
 void App::initialize(Application& self)
 {

--- a/Watchdog/App.cpp
+++ b/Watchdog/App.cpp
@@ -1,11 +1,6 @@
 #include "App.hpp"
+#include "NefLibIncludes.hpp"
 #include "DiagnosticsTraceHandler.hpp"
-
-#include <initguid.h>
-#include <devguid.h>
-
-#include <nefarius/neflib/MiscWinApi.hpp>
-#include <nefarius/neflib/ClassFilter.hpp>
 
 #pragma warning(disable: 26800)
 #include <spdlog/spdlog.h>

--- a/Watchdog/DiagnosticsTraceHandler.cpp
+++ b/Watchdog/DiagnosticsTraceHandler.cpp
@@ -1,0 +1,213 @@
+#include "DiagnosticsTraceHandler.hpp"
+
+#include "DiagnosticsTraceService.hpp"
+#include "HidHideDiagnosticsJson.hpp"
+
+#include <Poco/Exception.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Stringifier.h>
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTTPServerResponse.h>
+#include <Poco/StreamCopier.h>
+#include <Poco/URI.h>
+#include <Poco/UnicodeConverter.h>
+
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+    constexpr const char* kApiTraceBase = "/api/v1/diagnostics/trace";
+
+    std::string NormalizePath(std::string path)
+    {
+        while (!path.empty() && path.back() == '/')
+            path.pop_back();
+        return path;
+    }
+
+    void SendJson(Poco::Net::HTTPServerResponse& response,
+                  const int status,
+                  const Poco::JSON::Object& obj)
+    {
+        response.setStatus(static_cast<Poco::Net::HTTPResponse::HTTPStatus>(status));
+        response.setContentType("application/json");
+        std::ostream& out = response.send();
+        Poco::JSON::Stringifier::stringify(obj, out);
+    }
+
+    void SendError(Poco::Net::HTTPServerResponse& response,
+                   const int status,
+                   const hidhide::diag::ApiError& err)
+    {
+        Poco::JSON::Object root;
+        hidhide::diag::WriteErrorJson(root, err);
+        SendJson(response, status, root);
+    }
+
+    std::string WideToUtf8(const std::wstring& w)
+    {
+        std::string out;
+        Poco::UnicodeConverter::toUTF8(w, out);
+        return out;
+    }
+
+    class NotFoundHandler : public Poco::Net::HTTPRequestHandler
+    {
+    public:
+        void handleRequest(Poco::Net::HTTPServerRequest& request,
+                           Poco::Net::HTTPServerResponse& response) override
+        {
+            static_cast<void>(request);
+            hidhide::diag::ApiError err;
+            err.code = "not_found";
+            err.message = "The requested resource was not found.";
+            SendError(response, 404, err);
+        }
+    };
+
+    class DiagnosticsTraceHandler : public Poco::Net::HTTPRequestHandler
+    {
+    public:
+        void handleRequest(Poco::Net::HTTPServerRequest& request,
+                           Poco::Net::HTTPServerResponse& response) override
+        {
+            const std::string method = request.getMethod();
+            Poco::URI uri(request.getURI());
+            const std::string p = NormalizePath(uri.getPath());
+
+            if (p == kApiTraceBase && method == Poco::Net::HTTPRequest::HTTP_GET)
+                return HandleGetStatus(response);
+
+            if (p == kApiTraceBase && method == Poco::Net::HTTPRequest::HTTP_DELETE)
+                return HandleDelete(response);
+
+            if (p == std::string(kApiTraceBase) + "/start" && method == Poco::Net::HTTPRequest::HTTP_POST)
+                return HandlePostStart(request, response);
+
+            if (p == std::string(kApiTraceBase) + "/stop" && method == Poco::Net::HTTPRequest::HTTP_POST)
+                return HandlePostStop(response);
+
+            if (p == std::string(kApiTraceBase) + "/etl" && method == Poco::Net::HTTPRequest::HTTP_GET)
+                return HandleGetEtl(response);
+
+            hidhide::diag::ApiError err;
+            err.code = "not_found";
+            err.message = "Unknown diagnostics route.";
+            SendError(response, 404, err);
+        }
+
+    private:
+
+        static void HandleGetStatus(Poco::Net::HTTPServerResponse& response)
+        {
+            const auto r = DiagnosticsTraceService::Instance().GetStatus();
+            if (!r)
+                return SendError(response, 500, r.error());
+
+            Poco::JSON::Object root;
+            hidhide::diag::WriteStatusJson(root, *r);
+            SendJson(response, 200, root);
+        }
+
+        void HandlePostStart(Poco::Net::HTTPServerRequest& request,
+                             Poco::Net::HTTPServerResponse& response)
+        {
+            std::string body;
+            Poco::StreamCopier::copyToString(request.stream(), body);
+
+            hidhide::diag::TraceStartRequest parsed;
+            try
+            {
+                parsed = hidhide::diag::ParseStartBody(body);
+            }
+            catch (const Poco::Exception& ex)
+            {
+                hidhide::diag::ApiError err;
+                err.code = "bad_request";
+                err.message = std::string("Invalid JSON: ") + ex.what();
+                return SendError(response, 400, err);
+            }
+
+            const auto r = DiagnosticsTraceService::Instance().Start(parsed);
+            if (!r)
+            {
+                const int status = r.error().code == "recording_in_progress" ? 409 : 400;
+                return SendError(response, status, r.error());
+            }
+
+            Poco::JSON::Object root;
+            root.set("ok", true);
+            root.set("message", "Recording started.");
+            SendJson(response, 200, root);
+        }
+
+        static void HandlePostStop(Poco::Net::HTTPServerResponse& response)
+        {
+            const auto r = DiagnosticsTraceService::Instance().Stop();
+            if (!r)
+            {
+                const int status = r.error().code == "not_recording" ? 400 : 500;
+                return SendError(response, status, r.error());
+            }
+
+            Poco::JSON::Object root;
+            root.set("ok", true);
+            root.set("suggestedFileName", r->suggestedFileName);
+            if (r->message)
+                root.set("message", *r->message);
+            SendJson(response, 200, root);
+        }
+
+        static void HandleGetEtl(Poco::Net::HTTPServerResponse& response)
+        {
+            const auto pathW = DiagnosticsTraceService::Instance().GetEtlPathForDownload();
+            if (!pathW)
+                return SendError(response, 400, pathW.error());
+
+            std::ifstream in(fs::path(*pathW), std::ios::binary);
+            if (!in)
+            {
+                hidhide::diag::ApiError err;
+                err.code = "open_failed";
+                err.message = "Could not open capture file for reading.";
+                return SendError(response, 500, err);
+            }
+
+            const std::string attachName = WideToUtf8(fs::path(*pathW).filename().wstring());
+
+            response.setStatus(Poco::Net::HTTPResponse::HTTP_OK);
+            response.setContentType("application/octet-stream");
+            response.set("Content-Disposition", std::string("attachment; filename=\"") + attachName + "\"");
+
+            std::ostream& out = response.send();
+            out << in.rdbuf();
+        }
+
+        static void HandleDelete(Poco::Net::HTTPServerResponse& response)
+        {
+            const auto r = DiagnosticsTraceService::Instance().DiscardCapture();
+            if (!r)
+                return SendError(response, 500, r.error());
+
+            Poco::JSON::Object root;
+            root.set("ok", true);
+            root.set("message", "Capture discarded.");
+            SendJson(response, 200, root);
+        }
+    };
+}
+
+Poco::Net::HTTPRequestHandler* DiagnosticsHttpHandlerFactory::createRequestHandler(
+    const Poco::Net::HTTPServerRequest& request)
+{
+    Poco::URI uri(request.getURI());
+    const std::string path = NormalizePath(uri.getPath());
+
+    if (path.rfind("/api/v1/diagnostics/", 0) == 0)
+        return new DiagnosticsTraceHandler();
+
+    return new NotFoundHandler();
+}

--- a/Watchdog/DiagnosticsTraceHandler.cpp
+++ b/Watchdog/DiagnosticsTraceHandler.cpp
@@ -138,7 +138,8 @@ namespace
                 int status = 400;
                 if (code == "recording_in_progress")
                     status = 409;
-                else if (code == "trace_start_failed" || code == "channel_tune_failed")
+                else if (code == "trace_start_failed" || code == "channel_tune_failed" ||
+                         code == "previous_capture_delete_failed")
                     status = 500;
                 return SendError(response, status, r.error());
             }

--- a/Watchdog/DiagnosticsTraceHandler.cpp
+++ b/Watchdog/DiagnosticsTraceHandler.cpp
@@ -138,7 +138,7 @@ namespace
                 int status = 400;
                 if (code == "recording_in_progress")
                     status = 409;
-                else if (code == "trace_start_failed")
+                else if (code == "trace_start_failed" || code == "channel_tune_failed")
                     status = 500;
                 return SendError(response, status, r.error());
             }

--- a/Watchdog/DiagnosticsTraceHandler.cpp
+++ b/Watchdog/DiagnosticsTraceHandler.cpp
@@ -8,18 +8,22 @@
 #include <Poco/JSON/Stringifier.h>
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTTPServerResponse.h>
-#include <Poco/StreamCopier.h>
 #include <Poco/URI.h>
 #include <Poco/UnicodeConverter.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <istream>
+#include <vector>
 
 namespace fs = std::filesystem;
 
 namespace
 {
     constexpr const char* kApiTraceBase = "/api/v1/diagnostics/trace";
+    // POST /start JSON is tiny; cap prevents unbounded reads from Content-Length or chunked bodies.
+    constexpr std::streamsize kMaxTraceStartBodyBytes = 65536;
 
     std::string NormalizePath(std::string path)
     {
@@ -45,6 +49,52 @@ namespace
         Poco::JSON::Object root;
         hidhide::diag::WriteErrorJson(root, err);
         SendJson(response, status, root);
+    }
+
+    // Returns false if body exceeds kMaxTraceStartBodyBytes (errOut set) or extra bytes remain after limit.
+    bool ReadTraceStartBodyBounded(Poco::Net::HTTPServerRequest& request,
+                                   std::string& body,
+                                   hidhide::diag::ApiError& errOut)
+    {
+        const std::streamsize declared = request.getContentLength();
+        if (declared >= 0 && declared > kMaxTraceStartBodyBytes)
+        {
+            errOut.code = "payload_too_large";
+            errOut.message = "Request body exceeds maximum allowed size.";
+            return false;
+        }
+
+        body.clear();
+        if (declared > 0)
+            body.reserve(static_cast<size_t>(declared));
+
+        std::istream& in = request.stream();
+        std::vector<char> chunk(8192);
+        constexpr auto kMax = static_cast<size_t>(kMaxTraceStartBodyBytes);
+
+        while (body.size() < kMax)
+        {
+            const size_t want = std::min(chunk.size(), kMax - body.size());
+            in.read(chunk.data(), static_cast<std::streamsize>(want));
+            const std::streamsize got = in.gcount();
+            if (got <= 0)
+                break;
+            body.append(chunk.data(), static_cast<size_t>(got));
+        }
+
+        if (body.size() >= kMax)
+        {
+            char extra = {};
+            in.read(&extra, 1);
+            if (in.gcount() > 0)
+            {
+                errOut.code = "payload_too_large";
+                errOut.message = "Request body exceeds maximum allowed size.";
+                return false;
+            }
+        }
+
+        return true;
     }
 
     std::string WideToUtf8(const std::wstring& w)
@@ -116,7 +166,9 @@ namespace
                              Poco::Net::HTTPServerResponse& response)
         {
             std::string body;
-            Poco::StreamCopier::copyToString(request.stream(), body);
+            hidhide::diag::ApiError readErr;
+            if (!ReadTraceStartBodyBounded(request, body, readErr))
+                return SendError(response, 413, readErr);
 
             hidhide::diag::TraceStartRequest parsed;
             try

--- a/Watchdog/DiagnosticsTraceHandler.cpp
+++ b/Watchdog/DiagnosticsTraceHandler.cpp
@@ -134,7 +134,12 @@ namespace
             const auto r = DiagnosticsTraceService::Instance().Start(parsed);
             if (!r)
             {
-                const int status = r.error().code == "recording_in_progress" ? 409 : 400;
+                const std::string& code = r.error().code;
+                int status = 400;
+                if (code == "recording_in_progress")
+                    status = 409;
+                else if (code == "trace_start_failed")
+                    status = 500;
                 return SendError(response, status, r.error());
             }
 

--- a/Watchdog/DiagnosticsTraceHandler.hpp
+++ b/Watchdog/DiagnosticsTraceHandler.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <Poco/Net/HTTPRequestHandler.h>
+#include <Poco/Net/HTTPRequestHandlerFactory.h>
+
+class DiagnosticsHttpHandlerFactory : public Poco::Net::HTTPRequestHandlerFactory
+{
+public:
+    Poco::Net::HTTPRequestHandler* createRequestHandler(const Poco::Net::HTTPServerRequest& request) override;
+};

--- a/Watchdog/DiagnosticsTraceService.cpp
+++ b/Watchdog/DiagnosticsTraceService.cpp
@@ -1,0 +1,270 @@
+#include "DiagnosticsTraceService.hpp"
+
+#include "ETWUtil.h"
+
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <filesystem>
+#include <mutex>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+    constexpr wchar_t kChannelDriver[] = L"Nefarius-Drivers-HidHide/Diagnostic";
+    constexpr wchar_t kChannelClient[] = L"Nefarius-Drivers-HidHideClient/Diagnostic";
+    constexpr wchar_t kChannelCli[] = L"Nefarius-Drivers-HidHideCLI/Diagnostic";
+
+    hidhide::diag::ApiError MakeApiError(std::string code, std::string message, const unsigned long win32 = 0)
+    {
+        hidhide::diag::ApiError e;
+        e.code = std::move(code);
+        e.message = std::move(message);
+        if (win32 != 0)
+            e.win32 = win32;
+        return e;
+    }
+
+    void InvokeTune(const wchar_t* channel, const bool restore)
+    {
+        const auto r = restore
+                           ? etw::utils::RestoreReadmeDefaultDiagnosticVisibility(channel)
+                           : etw::utils::ApplyReadmeMaximumDiagnosticVisibility(channel);
+        if (!r)
+        {
+            spdlog::warn("Diagnostics channel {} failed: {}",
+                         restore ? "restore" : "tune",
+                         r.error().getErrorMessageA());
+        }
+    }
+
+    void TuneScopeChannels(const hidhide::diag::TraceScope scope, const bool restore)
+    {
+        switch (scope)
+        {
+        case hidhide::diag::TraceScope::Full:
+            InvokeTune(kChannelDriver, restore);
+            InvokeTune(kChannelClient, restore);
+            InvokeTune(kChannelCli, restore);
+            break;
+        case hidhide::diag::TraceScope::Driver:
+            InvokeTune(kChannelDriver, restore);
+            break;
+        case hidhide::diag::TraceScope::Userspace:
+            InvokeTune(kChannelClient, restore);
+            InvokeTune(kChannelCli, restore);
+            break;
+        }
+    }
+}
+
+DiagnosticsTraceService& DiagnosticsTraceService::Instance()
+{
+    static DiagnosticsTraceService s;
+    return s;
+}
+
+std::int64_t DiagnosticsTraceService::NowEpochSeconds()
+{
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+std::wstring DiagnosticsTraceService::ResolveOutputDirectory()
+{
+    wchar_t buf[MAX_PATH] = {};
+    const DWORD n = GetEnvironmentVariableW(L"PROGRAMDATA", buf, MAX_PATH);
+    std::wstring root;
+    if (n > 0 && n < MAX_PATH)
+        root.assign(buf, n);
+    else
+        root = L"C:\\ProgramData";
+
+    const fs::path dir = fs::path(root) / L"Nefarius" / L"HidHide" / L"ETW";
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    if (ec)
+    {
+        spdlog::error("Failed to create ETW output directory: {}", ec.message());
+    }
+    return dir.wstring();
+}
+
+std::wstring DiagnosticsTraceService::MakeUniqueEtlPath(const std::wstring& directory)
+{
+    SYSTEMTIME st{};
+    GetSystemTime(&st);
+    const unsigned tick = GetTickCount();
+    wchar_t name[160] = {};
+    swprintf_s(
+        name,
+        L"HidHide-trace-%04u%02u%02u-%02u%02u%02u-%08x.etl",
+        static_cast<unsigned>(st.wYear),
+        static_cast<unsigned>(st.wMonth),
+        static_cast<unsigned>(st.wDay),
+        static_cast<unsigned>(st.wHour),
+        static_cast<unsigned>(st.wMinute),
+        static_cast<unsigned>(st.wSecond),
+        tick);
+
+    return (fs::path(directory) / name).wstring();
+}
+
+std::expected<hidhide::diag::TraceStatusResponse, hidhide::diag::ApiError> DiagnosticsTraceService::GetStatus()
+                                                              const
+{
+    std::lock_guard lock(_mutex);
+
+    hidhide::diag::TraceStatusResponse r;
+    r.state = _state;
+    r.startedAtEpoch = _startedAtEpoch;
+    r.stoppedAtEpoch = _stoppedAtEpoch;
+    if (!_suggestedFileName.empty())
+        r.suggestedFileName = std::string(_suggestedFileName.begin(), _suggestedFileName.end());
+
+    return r;
+}
+
+std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::Start(
+    const hidhide::diag::TraceStartRequest& req)
+{
+    std::lock_guard lock(_mutex);
+
+    if (_state == hidhide::diag::TraceSessionState::Recording)
+    {
+        return std::unexpected(MakeApiError("recording_in_progress",
+                                            "A trace recording is already in progress."));
+    }
+
+    if (_state == hidhide::diag::TraceSessionState::Ready)
+    {
+        if (!_etlPath.empty())
+        {
+            std::error_code ec;
+            fs::remove(fs::path(_etlPath), ec);
+            if (ec)
+                spdlog::warn("Could not remove previous .etl before new start: {}", ec.message());
+        }
+        _stoppedAtEpoch.reset();
+        _suggestedFileName.clear();
+        _state = hidhide::diag::TraceSessionState::Idle;
+    }
+
+    _scope = req.scope;
+    _tuneChannels = req.tuneChannels;
+    _didTuneChannels = false;
+
+    const std::wstring dir = ResolveOutputDirectory();
+    _etlPath = MakeUniqueEtlPath(dir);
+    const fs::path p(_etlPath);
+    _suggestedFileName = p.filename().wstring();
+
+    if (_tuneChannels)
+    {
+        TuneScopeChannels(_scope, false);
+        _didTuneChannels = true;
+    }
+
+    if (const auto startResult = _trace.Start(_etlPath, _scope); !startResult)
+    {
+        if (_didTuneChannels)
+            TuneScopeChannels(_scope, true);
+
+        _didTuneChannels = false;
+        _etlPath.clear();
+        _suggestedFileName.clear();
+
+        return std::unexpected(MakeApiError(
+            "trace_start_failed",
+            std::string("Could not start trace session: ") + startResult.error().getErrorMessageA()));
+    }
+
+    _startedAtEpoch = NowEpochSeconds();
+    _stoppedAtEpoch.reset();
+    _state = hidhide::diag::TraceSessionState::Recording;
+
+    return {};
+}
+
+std::expected<hidhide::diag::TraceStopResponse, hidhide::diag::ApiError> DiagnosticsTraceService::Stop()
+{
+    std::lock_guard lock(_mutex);
+
+    if (_state != hidhide::diag::TraceSessionState::Recording)
+    {
+        return std::unexpected(
+            MakeApiError("not_recording", "No trace recording is active."));
+    }
+
+    if (const auto stopResult = _trace.Stop(); !stopResult)
+    {
+        return std::unexpected(MakeApiError(
+            "trace_stop_failed",
+            std::string("Could not stop trace session: ") + stopResult.error().getErrorMessageA()));
+    }
+
+    if (_didTuneChannels && _tuneChannels)
+        TuneScopeChannels(_scope, true);
+
+    _stoppedAtEpoch = NowEpochSeconds();
+    _state = hidhide::diag::TraceSessionState::Ready;
+
+    hidhide::diag::TraceStopResponse out;
+    out.suggestedFileName = std::string(_suggestedFileName.begin(), _suggestedFileName.end());
+    out.message = "Trace stopped; download the .etl file when ready.";
+
+    return out;
+}
+
+std::expected<std::wstring, hidhide::diag::ApiError> DiagnosticsTraceService::GetEtlPathForDownload() const
+{
+    std::lock_guard lock(_mutex);
+
+    if (_state != hidhide::diag::TraceSessionState::Ready)
+    {
+        return std::unexpected(
+            MakeApiError("not_ready", "Trace capture is not ready for download. Stop recording first."));
+    }
+
+    if (_etlPath.empty())
+        return std::unexpected(MakeApiError("missing_file", "Capture file path is unknown."));
+
+    if (!fs::exists(fs::path(_etlPath)))
+        return std::unexpected(MakeApiError("missing_file", "Capture file is no longer on disk."));
+
+    return _etlPath;
+}
+
+std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::DiscardCapture()
+{
+    std::lock_guard lock(_mutex);
+
+    if (_state == hidhide::diag::TraceSessionState::Recording)
+    {
+        if (const auto stopResult = _trace.Stop(); !stopResult)
+        {
+            spdlog::warn("DiscardCapture: stop failed: {}", stopResult.error().getErrorMessageA());
+        }
+        if (_didTuneChannels && _tuneChannels)
+            TuneScopeChannels(_scope, true);
+    }
+
+    if (!_etlPath.empty())
+    {
+        std::error_code ec;
+        fs::remove(fs::path(_etlPath), ec);
+        if (ec)
+            spdlog::warn("DiscardCapture: delete etl failed: {}", ec.message());
+    }
+
+    _etlPath.clear();
+    _suggestedFileName.clear();
+    _startedAtEpoch.reset();
+    _stoppedAtEpoch.reset();
+    _didTuneChannels = false;
+    _state = hidhide::diag::TraceSessionState::Idle;
+
+    return {};
+}

--- a/Watchdog/DiagnosticsTraceService.cpp
+++ b/Watchdog/DiagnosticsTraceService.cpp
@@ -198,7 +198,12 @@ std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::Start(
             std::error_code ec;
             fs::remove(fs::path(_etlPath), ec);
             if (ec)
+            {
                 spdlog::warn("Could not remove previous .etl before new start: {}", ec.message());
+                return std::unexpected(MakeApiError(
+                    "previous_capture_delete_failed",
+                    std::string("Could not remove previous capture file: ") + ec.message()));
+            }
         }
         _stoppedAtEpoch.reset();
         _startedAtEpoch.reset();
@@ -335,6 +340,9 @@ std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::DiscardCap
                     "Restoring diagnostics channels before discard"));
             }
         }
+        // Capture file exists on disk; transition out of Recording before delete attempt.
+        _stoppedAtEpoch = NowEpochSeconds();
+        _state = hidhide::diag::TraceSessionState::Ready;
     }
 
     if (!_etlPath.empty())
@@ -342,7 +350,12 @@ std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::DiscardCap
         std::error_code ec;
         fs::remove(fs::path(_etlPath), ec);
         if (ec)
+        {
             spdlog::warn("DiscardCapture: delete etl failed: {}", ec.message());
+            return std::unexpected(MakeApiError(
+                "capture_delete_failed",
+                std::string("Could not delete capture file: ") + ec.message()));
+        }
     }
 
     _etlPath.clear();

--- a/Watchdog/DiagnosticsTraceService.cpp
+++ b/Watchdog/DiagnosticsTraceService.cpp
@@ -344,6 +344,17 @@ std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::DiscardCap
         _stoppedAtEpoch = NowEpochSeconds();
         _state = hidhide::diag::TraceSessionState::Ready;
     }
+    else if (_state == hidhide::diag::TraceSessionState::Ready && _didTuneChannels && _tuneChannels)
+    {
+        if (const auto tr = TuneScopeChannels(_scope, true); !tr)
+        {
+            _stoppedAtEpoch = NowEpochSeconds();
+            _state = hidhide::diag::TraceSessionState::Ready;
+            return std::unexpected(ChannelTuneErrorToApi(
+                tr.error(),
+                "Restoring diagnostics channels before discard"));
+        }
+    }
 
     if (!_etlPath.empty())
     {

--- a/Watchdog/DiagnosticsTraceService.cpp
+++ b/Watchdog/DiagnosticsTraceService.cpp
@@ -181,6 +181,7 @@ std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::Start(
                 spdlog::warn("Could not remove previous .etl before new start: {}", ec.message());
         }
         _stoppedAtEpoch.reset();
+        _startedAtEpoch.reset();
         _suggestedFileName.clear();
         _state = hidhide::diag::TraceSessionState::Idle;
     }
@@ -208,6 +209,8 @@ std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::Start(
         _didTuneChannels = false;
         _etlPath.clear();
         _suggestedFileName.clear();
+        _startedAtEpoch.reset();
+        _stoppedAtEpoch.reset();
 
         return std::unexpected(MakeApiError(
             "trace_start_failed",
@@ -279,6 +282,9 @@ std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::DiscardCap
         if (const auto stopResult = _trace.Stop(); !stopResult)
         {
             spdlog::warn("DiscardCapture: stop failed: {}", stopResult.error().getErrorMessageA());
+            return std::unexpected(MakeApiError(
+                "trace_stop_failed",
+                std::string("Could not stop trace session: ") + stopResult.error().getErrorMessageA()));
         }
         if (_didTuneChannels && _tuneChannels)
             TuneScopeChannels(_scope, true);

--- a/Watchdog/DiagnosticsTraceService.cpp
+++ b/Watchdog/DiagnosticsTraceService.cpp
@@ -7,11 +7,44 @@
 #include <chrono>
 #include <filesystem>
 #include <mutex>
+#include <string_view>
 
 namespace fs = std::filesystem;
 
 namespace
 {
+    std::string WideToUtf8(const std::wstring_view w)
+    {
+        if (w.empty())
+            return {};
+
+        const int nbytes = WideCharToMultiByte(
+            CP_UTF8,
+            WC_ERR_INVALID_CHARS,
+            w.data(),
+            static_cast<int>(w.size()),
+            nullptr,
+            0,
+            nullptr,
+            nullptr);
+
+        if (nbytes <= 0)
+            return {};
+
+        std::string out(static_cast<size_t>(nbytes), '\0');
+        WideCharToMultiByte(
+            CP_UTF8,
+            WC_ERR_INVALID_CHARS,
+            w.data(),
+            static_cast<int>(w.size()),
+            out.data(),
+            nbytes,
+            nullptr,
+            nullptr);
+
+        return out;
+    }
+
     constexpr wchar_t kChannelDriver[] = L"Nefarius-Drivers-HidHide/Diagnostic";
     constexpr wchar_t kChannelClient[] = L"Nefarius-Drivers-HidHideClient/Diagnostic";
     constexpr wchar_t kChannelCli[] = L"Nefarius-Drivers-HidHideCLI/Diagnostic";
@@ -122,7 +155,7 @@ std::expected<hidhide::diag::TraceStatusResponse, hidhide::diag::ApiError> Diagn
     r.startedAtEpoch = _startedAtEpoch;
     r.stoppedAtEpoch = _stoppedAtEpoch;
     if (!_suggestedFileName.empty())
-        r.suggestedFileName = std::string(_suggestedFileName.begin(), _suggestedFileName.end());
+        r.suggestedFileName = WideToUtf8(_suggestedFileName);
 
     return r;
 }
@@ -212,7 +245,7 @@ std::expected<hidhide::diag::TraceStopResponse, hidhide::diag::ApiError> Diagnos
     _state = hidhide::diag::TraceSessionState::Ready;
 
     hidhide::diag::TraceStopResponse out;
-    out.suggestedFileName = std::string(_suggestedFileName.begin(), _suggestedFileName.end());
+    out.suggestedFileName = WideToUtf8(_suggestedFileName);
     out.message = "Trace stopped; download the .etl file when ready.";
 
     return out;

--- a/Watchdog/DiagnosticsTraceService.cpp
+++ b/Watchdog/DiagnosticsTraceService.cpp
@@ -7,7 +7,10 @@
 #include <chrono>
 #include <filesystem>
 #include <mutex>
+#include <string>
 #include <string_view>
+
+using TuneResult = std::expected<void, nefarius::utilities::Win32Error>;
 
 namespace fs = std::filesystem;
 
@@ -59,7 +62,15 @@ namespace
         return e;
     }
 
-    void InvokeTune(const wchar_t* channel, const bool restore)
+    hidhide::diag::ApiError ChannelTuneErrorToApi(const nefarius::utilities::Win32Error& err,
+                                                  std::string_view context)
+    {
+        return MakeApiError(
+            "channel_tune_failed",
+            std::string(context).append(": ").append(err.getErrorMessageA()));
+    }
+
+    TuneResult InvokeTune(const wchar_t* channel, const bool restore)
     {
         const auto r = restore
                            ? etw::utils::RestoreReadmeDefaultDiagnosticVisibility(channel)
@@ -69,26 +80,35 @@ namespace
             spdlog::warn("Diagnostics channel {} failed: {}",
                          restore ? "restore" : "tune",
                          r.error().getErrorMessageA());
+            return r;
         }
+        return {};
     }
 
-    void TuneScopeChannels(const hidhide::diag::TraceScope scope, const bool restore)
+    TuneResult TuneScopeChannels(const hidhide::diag::TraceScope scope, const bool restore)
     {
         switch (scope)
         {
         case hidhide::diag::TraceScope::Full:
-            InvokeTune(kChannelDriver, restore);
-            InvokeTune(kChannelClient, restore);
-            InvokeTune(kChannelCli, restore);
+            if (const auto r = InvokeTune(kChannelDriver, restore); !r)
+                return r;
+            if (const auto r = InvokeTune(kChannelClient, restore); !r)
+                return r;
+            if (const auto r = InvokeTune(kChannelCli, restore); !r)
+                return r;
             break;
         case hidhide::diag::TraceScope::Driver:
-            InvokeTune(kChannelDriver, restore);
+            if (const auto r = InvokeTune(kChannelDriver, restore); !r)
+                return r;
             break;
         case hidhide::diag::TraceScope::Userspace:
-            InvokeTune(kChannelClient, restore);
-            InvokeTune(kChannelCli, restore);
+            if (const auto r = InvokeTune(kChannelClient, restore); !r)
+                return r;
+            if (const auto r = InvokeTune(kChannelCli, restore); !r)
+                return r;
             break;
         }
+        return {};
     }
 }
 
@@ -197,14 +217,24 @@ std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::Start(
 
     if (_tuneChannels)
     {
-        TuneScopeChannels(_scope, false);
+        if (const auto tr = TuneScopeChannels(_scope, false); !tr)
+        {
+            _etlPath.clear();
+            _suggestedFileName.clear();
+            return std::unexpected(ChannelTuneErrorToApi(tr.error(), "Diagnostics channel tune"));
+        }
         _didTuneChannels = true;
     }
 
     if (const auto startResult = _trace.Start(_etlPath, _scope); !startResult)
     {
         if (_didTuneChannels)
-            TuneScopeChannels(_scope, true);
+        {
+            if (const auto tr = TuneScopeChannels(_scope, true); !tr)
+                return std::unexpected(ChannelTuneErrorToApi(
+                    tr.error(),
+                    "Restoring diagnostics channels after failed trace start"));
+        }
 
         _didTuneChannels = false;
         _etlPath.clear();
@@ -242,7 +272,15 @@ std::expected<hidhide::diag::TraceStopResponse, hidhide::diag::ApiError> Diagnos
     }
 
     if (_didTuneChannels && _tuneChannels)
-        TuneScopeChannels(_scope, true);
+    {
+        if (const auto tr = TuneScopeChannels(_scope, true); !tr)
+        {
+            _stoppedAtEpoch = NowEpochSeconds();
+            _state = hidhide::diag::TraceSessionState::Ready;
+            return std::unexpected(
+                ChannelTuneErrorToApi(tr.error(), "Restoring diagnostics channels after stop"));
+        }
+    }
 
     _stoppedAtEpoch = NowEpochSeconds();
     _state = hidhide::diag::TraceSessionState::Ready;
@@ -287,7 +325,16 @@ std::expected<void, hidhide::diag::ApiError> DiagnosticsTraceService::DiscardCap
                 std::string("Could not stop trace session: ") + stopResult.error().getErrorMessageA()));
         }
         if (_didTuneChannels && _tuneChannels)
-            TuneScopeChannels(_scope, true);
+        {
+            if (const auto tr = TuneScopeChannels(_scope, true); !tr)
+            {
+                _stoppedAtEpoch = NowEpochSeconds();
+                _state = hidhide::diag::TraceSessionState::Ready;
+                return std::unexpected(ChannelTuneErrorToApi(
+                    tr.error(),
+                    "Restoring diagnostics channels before discard"));
+            }
+        }
     }
 
     if (!_etlPath.empty())

--- a/Watchdog/DiagnosticsTraceService.hpp
+++ b/Watchdog/DiagnosticsTraceService.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "EtwTraceSession.hpp"
+#include "HidHideDiagnosticsTypes.hpp"
+
+#include <expected>
+#include <mutex>
+#include <string>
+
+//
+// Orchestrates Winevt channel tuning (README parity), single EtwTraceSession, and capture file paths.
+//
+class DiagnosticsTraceService
+{
+public:
+    static DiagnosticsTraceService& Instance();
+
+    std::expected<hidhide::diag::TraceStatusResponse, hidhide::diag::ApiError> GetStatus() const;
+
+    std::expected<void, hidhide::diag::ApiError> Start(const hidhide::diag::TraceStartRequest& req);
+
+    std::expected<hidhide::diag::TraceStopResponse, hidhide::diag::ApiError> Stop();
+
+    [[nodiscard]] std::expected<std::wstring, hidhide::diag::ApiError> GetEtlPathForDownload() const;
+
+    std::expected<void, hidhide::diag::ApiError> DiscardCapture();
+
+private:
+    DiagnosticsTraceService() = default;
+
+    mutable std::mutex _mutex;
+    hidhide::diag::TraceSessionState _state = hidhide::diag::TraceSessionState::Idle;
+    std::optional<std::int64_t> _startedAtEpoch;
+    std::optional<std::int64_t> _stoppedAtEpoch;
+    std::wstring _etlPath;
+    std::wstring _suggestedFileName;
+    hidhide::diag::TraceScope _scope = hidhide::diag::TraceScope::Full;
+    bool _tuneChannels = true;
+    bool _didTuneChannels = false;
+    EtwTraceSession _trace;
+
+    static std::int64_t NowEpochSeconds();
+
+    static std::wstring ResolveOutputDirectory();
+
+    static std::wstring MakeUniqueEtlPath(const std::wstring& directory);
+};

--- a/Watchdog/ETWUtil.cpp
+++ b/Watchdog/ETWUtil.cpp
@@ -3,22 +3,20 @@
 #include <scope_guard.hpp>
 
 #include <winevt.h>
-#include <evntrace.h>
-#include <tdh.h>
 #include <strsafe.h>
 
 using namespace nefarius::utilities;
 
 
-std::expected<void, Win32Error> etw::utils::SetLogEnabled(LPCWSTR channel, bool enabled)
+std::expected<void, Win32Error> etw::utils::SetLogEnabled(LPCWSTR channel, const bool enabled)
 {
-    EVT_HANDLE config = EvtOpenChannelConfig(NULL, channel, 0);
+    EVT_HANDLE config = EvtOpenChannelConfig(nullptr, channel, 0);
     if (!config)
     {
         return std::unexpected(Win32Error("EvtOpenChannelConfig"));
     }
 
-    auto guard = sg::make_scope_guard(
+    const auto guard = sg::make_scope_guard(
         [ config ]() noexcept
         {
             if (config)
@@ -31,7 +29,7 @@ std::expected<void, Win32Error> etw::utils::SetLogEnabled(LPCWSTR channel, bool 
 
     if (!EvtSetChannelConfigProperty(config, EvtChannelConfigEnabled, 0, &logEnabled))
     {
-        return std::unexpected(Win32Error("EvtSetChannelConfigProperty"));
+        return std::unexpected(Win32Error("EvtSetChannelConfigProperty EvtChannelConfigEnabled"));
     }
 
     if (!EvtSaveChannelConfig(config, 0))
@@ -42,59 +40,62 @@ std::expected<void, Win32Error> etw::utils::SetLogEnabled(LPCWSTR channel, bool 
     return {};
 }
 
-std::expected<void, Win32Error> etw::utils::StartSession()
+std::expected<void, Win32Error> etw::utils::SetDiagnosticChannelPublishingKeywords(
+    LPCWSTR channel,
+    const bool enabled,
+    const ULONGLONG publishingKeywords)
 {
-    // TODO: example code, finish and test!
-
-    TRACEHANDLE sessionHandle = 0;
-    EVENT_TRACE_PROPERTIES* sessionProperties = NULL;
-    DWORD bufferSize = sizeof(EVENT_TRACE_PROPERTIES) + sizeof(TCHAR) * (MAX_PATH + 1);
-    sessionProperties = (EVENT_TRACE_PROPERTIES*)malloc(bufferSize);
-    ZeroMemory(sessionProperties, bufferSize);
-
-    // Set the properties for the session
-    sessionProperties->Wnode.BufferSize = bufferSize;
-    sessionProperties->Wnode.Flags = WNODE_FLAG_TRACED_GUID;
-    sessionProperties->Wnode.ClientContext = 1; // QPC clock resolution
-    sessionProperties->Wnode.Guid = SystemTraceControlGuid; // GUID for kernel tracing
-    sessionProperties->LogFileMode = EVENT_TRACE_FILE_MODE_SEQUENTIAL; // Use file for output
-    sessionProperties->MaximumFileSize = 10; // Maximum size of log file in MB
-    sessionProperties->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
-    sessionProperties->LogFileNameOffset = sizeof(EVENT_TRACE_PROPERTIES) + sizeof(TCHAR) * (MAX_PATH + 1);
-
-
-    TCHAR logFileName[MAX_PATH] = TEXT("C:\\ETWLog.etl");
-    StringCchCopy((TCHAR*)(((char*)sessionProperties) + sessionProperties->LogFileNameOffset), MAX_PATH, logFileName);
-
-    TCHAR sessionName[MAX_PATH] = TEXT("MyETWSession");
-    ULONG status = StartTrace(&sessionHandle, sessionName, sessionProperties);
-
-    if (status != ERROR_SUCCESS)
+    EVT_HANDLE h = EvtOpenChannelConfig(nullptr, channel, 0);
+    if (!h)
     {
-        printf("Error starting trace session: %lu\n", status);
-        //return 1;
+        return std::unexpected(Win32Error("EvtOpenChannelConfig"));
     }
 
-    printf("ETW session started successfully!\n");
+    const auto guard = sg::make_scope_guard(
+        [ h ]() noexcept
+        {
+            if (h)
+                EvtClose(h);
+        });
 
-    status = EnableTraceEx2(
-        sessionHandle,
-        &SystemTraceControlGuid,
-        EVENT_CONTROL_CODE_ENABLE_PROVIDER,
-        TRACE_LEVEL_VERBOSE,
-        0,
-        0,
-        0,
-        NULL
-    );
-
-    if (status != ERROR_SUCCESS)
+    EVT_VARIANT off = {};
+    off.Type = EvtVarTypeBoolean;
+    off.BooleanVal = FALSE;
+    if (!EvtSetChannelConfigProperty(h, EvtChannelConfigEnabled, 0, &off))
     {
-        printf("Error enabling provider: %lu\n", status);
-        //return 1;
+        return std::unexpected(Win32Error("EvtSetChannelConfigProperty disable"));
     }
 
-    printf("Provider enabled successfully!\n");
+    EVT_VARIANT keywords = {};
+    keywords.Type = EvtVarTypeUInt64;
+    keywords.UInt64Val = publishingKeywords;
+    if (!EvtSetChannelConfigProperty(h, EvtChannelPublishingConfigKeywords, 0, &keywords))
+    {
+        return std::unexpected(Win32Error("EvtSetChannelConfigProperty Keywords"));
+    }
+
+    EVT_VARIANT on = {};
+    on.Type = EvtVarTypeBoolean;
+    on.BooleanVal = enabled ? TRUE : FALSE;
+    if (!EvtSetChannelConfigProperty(h, EvtChannelConfigEnabled, 0, &on))
+    {
+        return std::unexpected(Win32Error("EvtSetChannelConfigProperty enable"));
+    }
+
+    if (!EvtSaveChannelConfig(h, 0))
+    {
+        return std::unexpected(Win32Error("EvtSaveChannelConfig"));
+    }
 
     return {};
+}
+
+std::expected<void, Win32Error> etw::utils::ApplyReadmeMaximumDiagnosticVisibility(LPCWSTR channel)
+{
+    return SetDiagnosticChannelPublishingKeywords(channel, true, 5ull);
+}
+
+std::expected<void, Win32Error> etw::utils::RestoreReadmeDefaultDiagnosticVisibility(LPCWSTR channel)
+{
+    return SetDiagnosticChannelPublishingKeywords(channel, true, 1ull);
 }

--- a/Watchdog/ETWUtil.h
+++ b/Watchdog/ETWUtil.h
@@ -1,13 +1,6 @@
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-
-#include <expected>
-#include <string>
-#include <format>
-
-#include <nefarius/neflib/Win32Error.hpp>
+#include "NefLibIncludes.hpp"
 
 namespace etw::utils
 {

--- a/Watchdog/ETWUtil.h
+++ b/Watchdog/ETWUtil.h
@@ -13,5 +13,17 @@ namespace etw::utils
 {
     std::expected<void, nefarius::utilities::Win32Error> SetLogEnabled(LPCWSTR channel, bool enabled);
 
-    std::expected<void, nefarius::utilities::Win32Error> StartSession();
+    //
+    // Matches README.md wevtutil sequence for analytic Diagnostic channels:
+    // disable → set publishing keywords → enable → save.
+    // maxKeywords defaults to 5 and restoreKeywords to 1 (decimal), per README examples.
+    //
+    std::expected<void, nefarius::utilities::Win32Error> SetDiagnosticChannelPublishingKeywords(
+        LPCWSTR channel,
+        bool enabled,
+        ULONGLONG publishingKeywords);
+
+    std::expected<void, nefarius::utilities::Win32Error> ApplyReadmeMaximumDiagnosticVisibility(LPCWSTR channel);
+
+    std::expected<void, nefarius::utilities::Win32Error> RestoreReadmeDefaultDiagnosticVisibility(LPCWSTR channel);
 }

--- a/Watchdog/EtwTraceSession.cpp
+++ b/Watchdog/EtwTraceSession.cpp
@@ -2,6 +2,8 @@
 
 #include <cwchar>
 #include <cwctype>
+#include <iterator>
+#include <processthreadsapi.h>
 #include <strsafe.h>
 
 using nefarius::utilities::Win32Error;
@@ -117,8 +119,56 @@ namespace
         return false;
     }
 
-    // Query existing session; only stop if its log path is under our ProgramData ETW folder (avoids
-    // killing another logger that reused the name).
+    // True only if the trace session appears orphaned or owned by this process (recoverable), not
+    // another live HidHideWatchdog.exe instance.
+    bool LoggerThreadIndicatesSafeToStop(const EVENT_TRACE_PROPERTIES* qp)
+    {
+        static const wchar_t kWatchdogExe[] = L"HidHideWatchdog.exe";
+
+        const DWORD tid = qp->LoggerThreadId;
+        if (tid == 0)
+            return false;
+
+        const HANDLE ht = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, tid);
+        if (!ht)
+        {
+            // Logging thread is gone; session is orphaned.
+            return true;
+        }
+
+        const DWORD pid = GetProcessIdOfThread(ht);
+        CloseHandle(ht);
+        if (pid == 0)
+            return false;
+
+        const HANDLE hp = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+        if (!hp)
+        {
+            // Owner process has exited.
+            return true;
+        }
+
+        wchar_t image[1024]{};
+        DWORD sz = static_cast<DWORD>(std::size(image));
+        if (!QueryFullProcessImageNameW(hp, nullptr, image, &sz))
+        {
+            CloseHandle(hp);
+            return false;
+        }
+        CloseHandle(hp);
+
+        const wchar_t* base = wcsrchr(image, L'\\');
+        base = base ? base + 1 : image;
+        if (_wcsicmp(base, kWatchdogExe) != 0)
+            return false;
+
+        if (pid != GetCurrentProcessId())
+            return false;
+
+        return true;
+    }
+
+    // Query existing session; only stop after path + owner checks (avoid killing another live session).
     bool TryStopStaleOurSession()
     {
         ULONG kBytes = sizeof(EVENT_TRACE_PROPERTIES) + 32768;
@@ -155,6 +205,9 @@ namespace
         static const wchar_t kOurDirSlash[] = L"Nefarius/HidHide/ETW";
         if (!SubstringMatchInsensitive(logPath, kOurDirBackslash) &&
             !SubstringMatchInsensitive(logPath, kOurDirSlash))
+            return false;
+
+        if (!LoggerThreadIndicatesSafeToStop(qp))
             return false;
 
         const ULONG serr = ControlTraceW(0, EtwTraceSession::kSessionName, qp, EVENT_TRACE_CONTROL_STOP);
@@ -290,7 +343,8 @@ std::expected<void, Win32Error> EtwTraceSession::Start(const std::wstring& etlPa
     {
         if (const auto e = EnableProvider(_sessionHandle, g); !e)
         {
-            [[maybe_unused]] const auto unusedStop = Stop();
+            if (const auto stopErr = Stop(); !stopErr)
+                return stopErr;
             return e;
         }
     }

--- a/Watchdog/EtwTraceSession.cpp
+++ b/Watchdog/EtwTraceSession.cpp
@@ -1,5 +1,6 @@
 #include "EtwTraceSession.hpp"
 
+#include <cstdint>
 #include <cwchar>
 #include <cwctype>
 #include <iterator>
@@ -125,10 +126,12 @@ namespace
     {
         static const wchar_t kWatchdogExe[] = L"HidHideWatchdog.exe";
 
-        const DWORD tid = qp->LoggerThreadId;
-        if (tid == 0)
+        // SDK types this as HANDLE; ETW still supplies the logger thread id as an integer in this field.
+        const uintptr_t rawThreadId = reinterpret_cast<uintptr_t>(qp->LoggerThreadId);
+        if (rawThreadId == 0)
             return false;
 
+        const DWORD tid = static_cast<DWORD>(rawThreadId);
         const HANDLE ht = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, tid);
         if (!ht)
         {
@@ -150,7 +153,7 @@ namespace
 
         wchar_t image[1024]{};
         DWORD sz = static_cast<DWORD>(std::size(image));
-        if (!QueryFullProcessImageNameW(hp, nullptr, image, &sz))
+        if (!QueryFullProcessImageNameW(hp, 0, image, &sz))
         {
             CloseHandle(hp);
             return false;

--- a/Watchdog/EtwTraceSession.cpp
+++ b/Watchdog/EtwTraceSession.cpp
@@ -1,8 +1,5 @@
 #include "EtwTraceSession.hpp"
 
-#include <initguid.h>
-
-#include <evntrace.h>
 #include <strsafe.h>
 
 using nefarius::utilities::Win32Error;

--- a/Watchdog/EtwTraceSession.cpp
+++ b/Watchdog/EtwTraceSession.cpp
@@ -1,0 +1,252 @@
+#include "EtwTraceSession.hpp"
+
+#include <initguid.h>
+
+#include <evntrace.h>
+#include <strsafe.h>
+
+using nefarius::utilities::Win32Error;
+
+namespace
+{
+    // HidHide.man — EtwProviderLogging
+    DEFINE_GUID(GUID_HIDHIDE_DRIVER_LOGGING,
+                0x6da3ffa4,
+                0xab7d,
+                0x40e2,
+                0xb5,
+                0x0c,
+                0xc4,
+                0xb4,
+                0x1b,
+                0xba,
+                0x36,
+                0xe3);
+
+    // HidHide.man — EtwProviderTracing
+    DEFINE_GUID(GUID_HIDHIDE_DRIVER_TRACING,
+                0xd9f22586,
+                0x7514,
+                0x4164,
+                0xbb,
+                0x9b,
+                0x5c,
+                0x67,
+                0xd5,
+                0xbd,
+                0x2b,
+                0xc7);
+
+    // HidHideClient.man — EtwProviderLogging
+    DEFINE_GUID(GUID_HIDHIDE_CLIENT_LOGGING,
+                0x1e545280,
+                0x184f,
+                0x4954,
+                0xb1,
+                0xe4,
+                0x9b,
+                0xf8,
+                0x89,
+                0x8f,
+                0x25,
+                0x71);
+
+    // HidHideClient.man — EtwProviderTracing
+    DEFINE_GUID(GUID_HIDHIDE_CLIENT_TRACING,
+                0x3bea3f5d,
+                0xf523,
+                0x467e,
+                0x91,
+                0x2d,
+                0xe0,
+                0x1d,
+                0xcf,
+                0x6d,
+                0xad,
+                0xcf);
+
+    // HidHideCLI.man — EtwProviderLogging
+    DEFINE_GUID(GUID_HIDHIDE_CLI_LOGGING,
+                0xe3df118f,
+                0x1afc,
+                0x4630,
+                0x9f,
+                0x03,
+                0x6c,
+                0x6f,
+                0x73,
+                0x84,
+                0x87,
+                0x38);
+
+    // HidHideCLI.man — EtwProviderTracing
+    DEFINE_GUID(GUID_HIDHIDE_CLI_TRACING,
+                0x54c5b24f,
+                0x321d,
+                0x46b0,
+                0xbd,
+                0x2e,
+                0x79,
+                0xfd,
+                0xf7,
+                0xba,
+                0xb7,
+                0xac);
+
+    // Manifest keyword masks OR'd (Always | Debugging | Performance | Detailed)
+    constexpr ULONGLONG kTracingKeywordMaskAll = 0x1u | 0x2u | 0x4u | 0x8u;
+
+    constexpr UCHAR kTraceLevel = TRACE_LEVEL_VERBOSE;
+}
+
+constexpr wchar_t EtwTraceSession::kSessionName[];
+
+std::vector<GUID> EtwTraceSession::ProvidersForScope(const hidhide::diag::TraceScope scope)
+{
+    switch (scope)
+    {
+    case hidhide::diag::TraceScope::Full:
+        return {
+            GUID_HIDHIDE_DRIVER_LOGGING,
+            GUID_HIDHIDE_DRIVER_TRACING,
+            GUID_HIDHIDE_CLIENT_LOGGING,
+            GUID_HIDHIDE_CLIENT_TRACING,
+            GUID_HIDHIDE_CLI_LOGGING,
+            GUID_HIDHIDE_CLI_TRACING,
+        };
+    case hidhide::diag::TraceScope::Driver:
+        return {
+            GUID_HIDHIDE_DRIVER_LOGGING,
+            GUID_HIDHIDE_DRIVER_TRACING,
+        };
+    case hidhide::diag::TraceScope::Userspace:
+        return {
+            GUID_HIDHIDE_CLIENT_LOGGING,
+            GUID_HIDHIDE_CLIENT_TRACING,
+            GUID_HIDHIDE_CLI_LOGGING,
+            GUID_HIDHIDE_CLI_TRACING,
+        };
+    }
+    return {};
+}
+
+std::expected<void, Win32Error> EtwTraceSession::EnableProvider(const TRACEHANDLE session,
+                                                                const GUID& providerGuid)
+{
+    const ULONGLONG anyKeyword = kTracingKeywordMaskAll;
+    const ULONG status = EnableTraceEx2(
+        session,
+        &providerGuid,
+        EVENT_CONTROL_CODE_ENABLE_PROVIDER,
+        kTraceLevel,
+        anyKeyword,
+        0,
+        0,
+        nullptr);
+
+    if (status != ERROR_SUCCESS)
+    {
+        ::SetLastError(status);
+        return std::unexpected(Win32Error("EnableTraceEx2"));
+    }
+
+    return {};
+}
+
+std::expected<void, Win32Error> EtwTraceSession::Start(const std::wstring& etlPath,
+                                                       const hidhide::diag::TraceScope scope)
+{
+    if (_sessionHandle != 0)
+    {
+        ::SetLastError(ERROR_ALREADY_EXISTS);
+        return std::unexpected(Win32Error("EtwTraceSession::Start"));
+    }
+
+    // Remove stale session from a previous crash / abrupt termination.
+    {
+        constexpr ULONG kCleanupBytes = sizeof(EVENT_TRACE_PROPERTIES) + 8192;
+        std::vector<BYTE> cleanup(kCleanupBytes);
+        auto* cp = reinterpret_cast<EVENT_TRACE_PROPERTIES*>(cleanup.data());
+        ZeroMemory(cp, kCleanupBytes);
+        cp->Wnode.BufferSize = kCleanupBytes;
+        cp->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
+        ControlTraceW(0, kSessionName, cp, EVENT_TRACE_CONTROL_STOP);
+    }
+
+    const std::wstring& sessionName = std::wstring(kSessionName);
+    const ULONG nameChars = static_cast<ULONG>(sessionName.size() + 1);
+    const ULONG pathChars = static_cast<ULONG>(etlPath.size() + 1);
+    const ULONG bufferSize = sizeof(EVENT_TRACE_PROPERTIES) + (nameChars + pathChars) * sizeof(WCHAR);
+
+    std::vector<BYTE> buffer(bufferSize);
+    auto* props = reinterpret_cast<EVENT_TRACE_PROPERTIES*>(buffer.data());
+    ZeroMemory(props, bufferSize);
+
+    props->Wnode.BufferSize = bufferSize;
+    props->Wnode.Flags = WNODE_FLAG_TRACED_GUID;
+    props->Wnode.ClientContext = 1;
+    props->Wnode.Guid = GUID{};
+    props->LogFileMode = EVENT_TRACE_FILE_MODE_SEQUENTIAL;
+    props->MaximumFileSize = 128;
+    props->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
+    props->LogFileNameOffset = sizeof(EVENT_TRACE_PROPERTIES) + nameChars * sizeof(WCHAR);
+
+    const HRESULT hrName = StringCbCopyW(
+        reinterpret_cast<WSTR>(buffer.data() + props->LoggerNameOffset),
+        nameChars * sizeof(WCHAR),
+        sessionName.c_str());
+    if (!SUCCEEDED(hrName))
+        return std::unexpected(Win32Error(static_cast<DWORD>(ERROR_INVALID_PARAMETER), std::string("StringCbCopyW logger")));
+
+    const HRESULT hrPath = StringCbCopyW(
+        reinterpret_cast<WSTR>(buffer.data() + props->LogFileNameOffset),
+        pathChars * sizeof(WCHAR),
+        etlPath.c_str());
+    if (!SUCCEEDED(hrPath))
+        return std::unexpected(Win32Error(static_cast<DWORD>(ERROR_INVALID_PARAMETER), std::string("StringCbCopyW log path")));
+
+    const ULONG errStart = StartTraceW(&_sessionHandle, sessionName.c_str(), props);
+    if (errStart != ERROR_SUCCESS)
+    {
+        _sessionHandle = 0;
+        ::SetLastError(errStart);
+        return std::unexpected(Win32Error("StartTraceW"));
+    }
+
+    const auto providers = ProvidersForScope(scope);
+    for (const auto& g : providers)
+    {
+        if (const auto e = EnableProvider(_sessionHandle, g); !e)
+        {
+            Stop();
+            return e;
+        }
+    }
+
+    return {};
+}
+
+std::expected<void, Win32Error> EtwTraceSession::Stop()
+{
+    if (_sessionHandle == 0)
+        return {};
+
+    const ULONG bufSize = sizeof(EVENT_TRACE_PROPERTIES) + sizeof(WCHAR) * 512;
+    std::vector<BYTE> buffer(bufSize);
+    auto* props = reinterpret_cast<EVENT_TRACE_PROPERTIES*>(buffer.data());
+    ZeroMemory(props, bufSize);
+    props->Wnode.BufferSize = bufSize;
+
+    const TRACEHANDLE h = _sessionHandle;
+    _sessionHandle = 0;
+
+    const ULONG errStop = ControlTraceW(h, nullptr, props, EVENT_TRACE_CONTROL_STOP);
+
+    if (errStop != ERROR_SUCCESS)
+    {
+        ::SetLastError(errStop);
+        return std::unexpected(Win32Error("ControlTrace STOP"));
+    }
+
+    return {};
+}

--- a/Watchdog/EtwTraceSession.cpp
+++ b/Watchdog/EtwTraceSession.cpp
@@ -192,14 +192,14 @@ std::expected<void, Win32Error> EtwTraceSession::Start(const std::wstring& etlPa
     props->LogFileNameOffset = sizeof(EVENT_TRACE_PROPERTIES) + nameChars * sizeof(WCHAR);
 
     const HRESULT hrName = StringCbCopyW(
-        reinterpret_cast<WSTR>(buffer.data() + props->LoggerNameOffset),
+        reinterpret_cast<wchar_t*>(buffer.data() + props->LoggerNameOffset),
         nameChars * sizeof(WCHAR),
         sessionName.c_str());
     if (!SUCCEEDED(hrName))
         return std::unexpected(Win32Error(static_cast<DWORD>(ERROR_INVALID_PARAMETER), std::string("StringCbCopyW logger")));
 
     const HRESULT hrPath = StringCbCopyW(
-        reinterpret_cast<WSTR>(buffer.data() + props->LogFileNameOffset),
+        reinterpret_cast<wchar_t*>(buffer.data() + props->LogFileNameOffset),
         pathChars * sizeof(WCHAR),
         etlPath.c_str());
     if (!SUCCEEDED(hrPath))
@@ -218,7 +218,7 @@ std::expected<void, Win32Error> EtwTraceSession::Start(const std::wstring& etlPa
     {
         if (const auto e = EnableProvider(_sessionHandle, g); !e)
         {
-            Stop();
+            [[maybe_unused]] const auto unusedStop = Stop();
             return e;
         }
     }

--- a/Watchdog/EtwTraceSession.cpp
+++ b/Watchdog/EtwTraceSession.cpp
@@ -120,6 +120,19 @@ namespace
         return false;
     }
 
+    // OpenThread/OpenProcess failure is only treated as "target gone" when LastError matches these.
+    bool Win32ErrorIndicatesMissingThreadOrProcess(const DWORD err)
+    {
+        switch (err)
+        {
+        case ERROR_INVALID_PARAMETER:
+        case ERROR_NOT_FOUND:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     // True only if the trace session appears orphaned or owned by this process (recoverable), not
     // another live HidHideWatchdog.exe instance.
     bool LoggerThreadIndicatesSafeToStop(const EVENT_TRACE_PROPERTIES* qp)
@@ -135,8 +148,10 @@ namespace
         const HANDLE ht = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, tid);
         if (!ht)
         {
-            // Logging thread is gone; session is orphaned.
-            return true;
+            const DWORD openThreadErr = ::GetLastError();
+            if (Win32ErrorIndicatesMissingThreadOrProcess(openThreadErr))
+                return true;
+            return false;
         }
 
         const DWORD pid = GetProcessIdOfThread(ht);
@@ -147,8 +162,10 @@ namespace
         const HANDLE hp = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
         if (!hp)
         {
-            // Owner process has exited.
-            return true;
+            const DWORD openProcessErr = ::GetLastError();
+            if (Win32ErrorIndicatesMissingThreadOrProcess(openProcessErr))
+                return true;
+            return false;
         }
 
         wchar_t image[1024]{};

--- a/Watchdog/EtwTraceSession.cpp
+++ b/Watchdog/EtwTraceSession.cpp
@@ -1,5 +1,7 @@
 #include "EtwTraceSession.hpp"
 
+#include <cwchar>
+#include <cwctype>
 #include <strsafe.h>
 
 using nefarius::utilities::Win32Error;
@@ -94,6 +96,70 @@ namespace
     constexpr ULONGLONG kTracingKeywordMaskAll = 0x1u | 0x2u | 0x4u | 0x8u;
 
     constexpr UCHAR kTraceLevel = TRACE_LEVEL_VERBOSE;
+
+    bool SubstringMatchInsensitive(const wchar_t* haystack, const wchar_t* needle)
+    {
+        if (!haystack || !needle || !*needle)
+            return false;
+        for (const wchar_t* p = haystack; *p; ++p)
+        {
+            const wchar_t* a = p;
+            const wchar_t* b = needle;
+            while (*a && *b &&
+                   towlower(static_cast<wint_t>(*a)) == towlower(static_cast<wint_t>(*b)))
+            {
+                ++a;
+                ++b;
+            }
+            if (!*b)
+                return true;
+        }
+        return false;
+    }
+
+    // Query existing session; only stop if its log path is under our ProgramData ETW folder (avoids
+    // killing another logger that reused the name).
+    bool TryStopStaleOurSession()
+    {
+        ULONG kBytes = sizeof(EVENT_TRACE_PROPERTIES) + 32768;
+        std::vector<BYTE> buf(kBytes);
+        EVENT_TRACE_PROPERTIES* qp = nullptr;
+        ULONG qerr = ERROR_SUCCESS;
+        do
+        {
+            buf.resize(kBytes);
+            qp = reinterpret_cast<EVENT_TRACE_PROPERTIES*>(buf.data());
+            ZeroMemory(qp, kBytes);
+            qp->Wnode.BufferSize = kBytes;
+            qp->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
+            qp->LogFileNameOffset = sizeof(EVENT_TRACE_PROPERTIES) + 512 * sizeof(WCHAR);
+            qerr = QueryTraceW(0, EtwTraceSession::kSessionName, qp);
+            if (qerr == ERROR_MORE_DATA && kBytes < 512 * 1024)
+                kBytes *= 2;
+            else
+                break;
+        } while (qerr == ERROR_MORE_DATA);
+
+        if (qerr != ERROR_SUCCESS)
+            return false;
+
+        if (qp->LogFileNameOffset == 0 || qp->LogFileNameOffset >= buf.size())
+            return false;
+
+        const wchar_t* logPath =
+            reinterpret_cast<const wchar_t*>(buf.data() + qp->LogFileNameOffset);
+        if (!logPath || !logPath[0])
+            return false;
+
+        static const wchar_t kOurDirBackslash[] = L"Nefarius\\HidHide\\ETW";
+        static const wchar_t kOurDirSlash[] = L"Nefarius/HidHide/ETW";
+        if (!SubstringMatchInsensitive(logPath, kOurDirBackslash) &&
+            !SubstringMatchInsensitive(logPath, kOurDirSlash))
+            return false;
+
+        const ULONG serr = ControlTraceW(0, EtwTraceSession::kSessionName, qp, EVENT_TRACE_CONTROL_STOP);
+        return serr == ERROR_SUCCESS;
+    }
 }
 
 constexpr wchar_t EtwTraceSession::kSessionName[];
@@ -159,17 +225,6 @@ std::expected<void, Win32Error> EtwTraceSession::Start(const std::wstring& etlPa
         return std::unexpected(Win32Error("EtwTraceSession::Start"));
     }
 
-    // Remove stale session from a previous crash / abrupt termination.
-    {
-        constexpr ULONG kCleanupBytes = sizeof(EVENT_TRACE_PROPERTIES) + 8192;
-        std::vector<BYTE> cleanup(kCleanupBytes);
-        auto* cp = reinterpret_cast<EVENT_TRACE_PROPERTIES*>(cleanup.data());
-        ZeroMemory(cp, kCleanupBytes);
-        cp->Wnode.BufferSize = kCleanupBytes;
-        cp->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
-        ControlTraceW(0, kSessionName, cp, EVENT_TRACE_CONTROL_STOP);
-    }
-
     const std::wstring& sessionName = std::wstring(kSessionName);
     const ULONG nameChars = static_cast<ULONG>(sessionName.size() + 1);
     const ULONG pathChars = static_cast<ULONG>(etlPath.size() + 1);
@@ -177,37 +232,57 @@ std::expected<void, Win32Error> EtwTraceSession::Start(const std::wstring& etlPa
 
     std::vector<BYTE> buffer(bufferSize);
     auto* props = reinterpret_cast<EVENT_TRACE_PROPERTIES*>(buffer.data());
-    ZeroMemory(props, bufferSize);
 
-    props->Wnode.BufferSize = bufferSize;
-    props->Wnode.Flags = WNODE_FLAG_TRACED_GUID;
-    props->Wnode.ClientContext = 1;
-    props->Wnode.Guid = GUID{};
-    props->LogFileMode = EVENT_TRACE_FILE_MODE_SEQUENTIAL;
-    props->MaximumFileSize = 128;
-    props->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
-    props->LogFileNameOffset = sizeof(EVENT_TRACE_PROPERTIES) + nameChars * sizeof(WCHAR);
+    const auto fillProps = [&]() -> std::expected<void, Win32Error>
+    {
+        ZeroMemory(props, bufferSize);
+        props->Wnode.BufferSize = bufferSize;
+        props->Wnode.Flags = WNODE_FLAG_TRACED_GUID;
+        props->Wnode.ClientContext = 1;
+        props->Wnode.Guid = GUID{};
+        props->LogFileMode = EVENT_TRACE_FILE_MODE_SEQUENTIAL;
+        props->MaximumFileSize = 128;
+        props->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
+        props->LogFileNameOffset = sizeof(EVENT_TRACE_PROPERTIES) + nameChars * sizeof(WCHAR);
 
-    const HRESULT hrName = StringCbCopyW(
-        reinterpret_cast<wchar_t*>(buffer.data() + props->LoggerNameOffset),
-        nameChars * sizeof(WCHAR),
-        sessionName.c_str());
-    if (!SUCCEEDED(hrName))
-        return std::unexpected(Win32Error(static_cast<DWORD>(ERROR_INVALID_PARAMETER), std::string("StringCbCopyW logger")));
+        const HRESULT hrName = StringCbCopyW(
+            reinterpret_cast<wchar_t*>(buffer.data() + props->LoggerNameOffset),
+            nameChars * sizeof(WCHAR),
+            sessionName.c_str());
+        if (!SUCCEEDED(hrName))
+            return std::unexpected(
+                Win32Error(static_cast<DWORD>(ERROR_INVALID_PARAMETER), std::string("StringCbCopyW logger")));
 
-    const HRESULT hrPath = StringCbCopyW(
-        reinterpret_cast<wchar_t*>(buffer.data() + props->LogFileNameOffset),
-        pathChars * sizeof(WCHAR),
-        etlPath.c_str());
-    if (!SUCCEEDED(hrPath))
-        return std::unexpected(Win32Error(static_cast<DWORD>(ERROR_INVALID_PARAMETER), std::string("StringCbCopyW log path")));
+        const HRESULT hrPath = StringCbCopyW(
+            reinterpret_cast<wchar_t*>(buffer.data() + props->LogFileNameOffset),
+            pathChars * sizeof(WCHAR),
+            etlPath.c_str());
+        if (!SUCCEEDED(hrPath))
+            return std::unexpected(
+                Win32Error(static_cast<DWORD>(ERROR_INVALID_PARAMETER), std::string("StringCbCopyW log path")));
 
-    const ULONG errStart = StartTraceW(&_sessionHandle, sessionName.c_str(), props);
+        return {};
+    };
+
+    if (const auto filled = fillProps(); !filled)
+        return filled;
+
+    ULONG errStart = StartTraceW(&_sessionHandle, sessionName.c_str(), props);
     if (errStart != ERROR_SUCCESS)
     {
         _sessionHandle = 0;
-        ::SetLastError(errStart);
-        return std::unexpected(Win32Error("StartTraceW"));
+        if (errStart == ERROR_ALREADY_EXISTS && TryStopStaleOurSession())
+        {
+            if (const auto filled = fillProps(); !filled)
+                return filled;
+            errStart = StartTraceW(&_sessionHandle, sessionName.c_str(), props);
+        }
+        if (errStart != ERROR_SUCCESS)
+        {
+            _sessionHandle = 0;
+            ::SetLastError(errStart);
+            return std::unexpected(Win32Error("StartTraceW"));
+        }
     }
 
     const auto providers = ProvidersForScope(scope);
@@ -235,7 +310,6 @@ std::expected<void, Win32Error> EtwTraceSession::Stop()
     props->Wnode.BufferSize = bufSize;
 
     const TRACEHANDLE h = _sessionHandle;
-    _sessionHandle = 0;
 
     const ULONG errStop = ControlTraceW(h, nullptr, props, EVENT_TRACE_CONTROL_STOP);
 
@@ -245,5 +319,6 @@ std::expected<void, Win32Error> EtwTraceSession::Stop()
         return std::unexpected(Win32Error("ControlTrace STOP"));
     }
 
+    _sessionHandle = 0;
     return {};
 }

--- a/Watchdog/EtwTraceSession.hpp
+++ b/Watchdog/EtwTraceSession.hpp
@@ -1,14 +1,7 @@
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include "NefLibIncludes.hpp"
 #include <evntrace.h>
-
-#include <expected>
-#include <string>
-#include <vector>
-
-#include <nefarius/neflib/Win32Error.hpp>
 
 #include "HidHideDiagnosticsTypes.hpp"
 

--- a/Watchdog/EtwTraceSession.hpp
+++ b/Watchdog/EtwTraceSession.hpp
@@ -2,6 +2,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#include <evntrace.h>
 
 #include <expected>
 #include <string>

--- a/Watchdog/EtwTraceSession.hpp
+++ b/Watchdog/EtwTraceSession.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <expected>
+#include <string>
+#include <vector>
+
+#include <nefarius/neflib/Win32Error.hpp>
+
+#include "HidHideDiagnosticsTypes.hpp"
+
+//
+// Single-instance user-mode file trace session for HidHide ETW providers only.
+//
+class EtwTraceSession
+{
+public:
+    static constexpr wchar_t kSessionName[] = L"HidHideFieldTrace";
+
+    std::expected<void, nefarius::utilities::Win32Error> Start(
+        const std::wstring& etlPath,
+        hidhide::diag::TraceScope scope);
+
+    std::expected<void, nefarius::utilities::Win32Error> Stop();
+
+    [[nodiscard]] bool IsActive() const noexcept { return _sessionHandle != 0; }
+
+private:
+    TRACEHANDLE _sessionHandle = 0;
+
+    static std::vector<GUID> ProvidersForScope(hidhide::diag::TraceScope scope);
+
+    static std::expected<void, nefarius::utilities::Win32Error> EnableProvider(TRACEHANDLE session,
+                                                                                 const GUID& providerGuid);
+};

--- a/Watchdog/HidHideDiagnosticsJson.cpp
+++ b/Watchdog/HidHideDiagnosticsJson.cpp
@@ -1,0 +1,95 @@
+#include "HidHideDiagnosticsTypes.hpp"
+
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+
+#include <algorithm>
+#include <cctype>
+
+namespace hidhide::diag
+{
+    namespace
+    {
+        bool IEquals(std::string_view a, std::string_view b)
+        {
+            if (a.size() != b.size())
+                return false;
+            for (size_t i = 0; i < a.size(); ++i)
+            {
+                const unsigned char ca = static_cast<unsigned char>(a[i]);
+                const unsigned char cb = static_cast<unsigned char>(b[i]);
+                if (std::tolower(ca) != std::tolower(cb))
+                    return false;
+            }
+            return true;
+        }
+    }
+
+    std::optional<TraceScope> ParseScope(const std::string_view value)
+    {
+        if (IEquals(value, "full"))
+            return TraceScope::Full;
+        if (IEquals(value, "driver"))
+            return TraceScope::Driver;
+        if (IEquals(value, "userspace"))
+            return TraceScope::Userspace;
+        return std::nullopt;
+    }
+
+    TraceStartRequest ParseStartBody(const std::string& jsonUtf8)
+    {
+        TraceStartRequest req{};
+        if (jsonUtf8.empty())
+            return req;
+
+        Poco::JSON::Parser parser;
+        const auto result = parser.parse(jsonUtf8);
+        const auto obj = result.extract<Poco::JSON::Object::Ptr>();
+        if (!obj)
+            return req;
+
+        if (obj->has("scope"))
+            if (const auto s = ParseScope(obj->getValue<std::string>("scope")))
+                req.scope = *s;
+
+        if (obj->has("tuneChannels"))
+            req.tuneChannels = obj->getValue<bool>("tuneChannels");
+
+        return req;
+    }
+
+    void WriteStatusJson(Poco::JSON::Object& out, const TraceStatusResponse& r)
+    {
+        switch (r.state)
+        {
+        case TraceSessionState::Idle:
+            out.set("state", "idle");
+            break;
+        case TraceSessionState::Recording:
+            out.set("state", "recording");
+            break;
+        case TraceSessionState::Ready:
+            out.set("state", "ready");
+            break;
+        }
+
+        if (r.startedAtEpoch)
+            out.set("startedAt", static_cast<Poco::Int64>(*r.startedAtEpoch));
+        if (r.stoppedAtEpoch)
+            out.set("stoppedAt", static_cast<Poco::Int64>(*r.stoppedAtEpoch));
+        if (r.suggestedFileName)
+            out.set("suggestedFileName", *r.suggestedFileName);
+        if (r.message)
+            out.set("message", *r.message);
+    }
+
+    void WriteErrorJson(Poco::JSON::Object& out, const ApiError& e)
+    {
+        Poco::JSON::Object err;
+        err.set("code", e.code);
+        err.set("message", e.message);
+        if (e.win32)
+            err.set("win32", static_cast<Poco::Int64>(*e.win32));
+        out.set("error", err);
+    }
+}

--- a/Watchdog/HidHideDiagnosticsJson.hpp
+++ b/Watchdog/HidHideDiagnosticsJson.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "HidHideDiagnosticsTypes.hpp"
+
+#include <Poco/JSON/Object.h>
+
+#include <string>
+
+namespace hidhide::diag
+{
+    TraceStartRequest ParseStartBody(const std::string& jsonUtf8);
+
+    void WriteStatusJson(Poco::JSON::Object& out, const TraceStatusResponse& r);
+
+    void WriteErrorJson(Poco::JSON::Object& out, const ApiError& e);
+}

--- a/Watchdog/HidHideDiagnosticsTypes.hpp
+++ b/Watchdog/HidHideDiagnosticsTypes.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace hidhide::diag
+{
+    enum class TraceScope
+    {
+        Full,
+        Driver,
+        Userspace
+    };
+
+    enum class TraceSessionState
+    {
+        Idle,
+        Recording,
+        Ready
+    };
+
+    struct TraceStartRequest
+    {
+        TraceScope scope = TraceScope::Full;
+        bool tuneChannels = true;
+    };
+
+    struct TraceStatusResponse
+    {
+        TraceSessionState state = TraceSessionState::Idle;
+        std::optional<std::int64_t> startedAtEpoch;
+        std::optional<std::int64_t> stoppedAtEpoch;
+        std::optional<std::string> suggestedFileName;
+        std::optional<std::string> message;
+    };
+
+    struct TraceStopResponse
+    {
+        std::string suggestedFileName;
+        std::optional<std::string> message;
+    };
+
+    struct ApiError
+    {
+        std::string code;
+        std::string message;
+        std::optional<unsigned long> win32;
+    };
+
+    std::optional<TraceScope> ParseScope(std::string_view value);
+}

--- a/Watchdog/NefLibIncludes.hpp
+++ b/Watchdog/NefLibIncludes.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+//
+// Required include order for neflib (C++23):
+// https://github.com/nefarius/neflib#includes
+//
+
+//
+// WinAPI
+//
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+#include <ShlObj.h>
+#include <SetupAPI.h>
+#include <newdev.h>
+#include <tchar.h>
+#include <initguid.h>
+#include <devguid.h>
+#include <shellapi.h>
+#include <TlHelp32.h>
+#include <cfgmgr32.h>
+
+//
+// STL consumed by neflib
+//
+#include <string>
+#include <type_traits>
+#include <vector>
+#include <format>
+#include <expected>
+#include <algorithm>
+#include <variant>
+
+//
+// vcpkg (neflib dependency)
+//
+#include <wil/resource.h>
+
+//
+// neflib public headers (order preserved)
+//
+#include <nefarius/neflib/AnyString.hpp>
+#include <nefarius/neflib/UniUtil.hpp>
+#include <nefarius/neflib/HDEVINFOHandleGuard.hpp>
+#include <nefarius/neflib/HKEYHandleGuard.hpp>
+#include <nefarius/neflib/INFHandleGuard.hpp>
+#include <nefarius/neflib/GenHandleGuard.hpp>
+#include <nefarius/neflib/LibraryHelper.hpp>
+#include <nefarius/neflib/MultiStringArray.hpp>
+#include <nefarius/neflib/Win32Error.hpp>
+#include <nefarius/neflib/ClassFilter.hpp>
+#include <nefarius/neflib/Devcon.hpp>
+#include <nefarius/neflib/MiscWinApi.hpp>

--- a/Watchdog/Watchdog.vcxproj
+++ b/Watchdog/Watchdog.vcxproj
@@ -326,6 +326,7 @@
     <ClInclude Include="EtwTraceSession.hpp" />
     <ClInclude Include="HidHideDiagnosticsJson.hpp" />
     <ClInclude Include="HidHideDiagnosticsTypes.hpp" />
+    <ClInclude Include="NefLibIncludes.hpp" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="resource1.h" />
   </ItemGroup>

--- a/Watchdog/Watchdog.vcxproj
+++ b/Watchdog/Watchdog.vcxproj
@@ -317,12 +317,14 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="App.cpp" />
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(EnableWatchdogHttp)'=='true'">
     <ClCompile Include="DiagnosticsTraceHandler.cpp" />
     <ClCompile Include="DiagnosticsTraceService.cpp" />
     <ClCompile Include="ETWUtil.cpp" />
     <ClCompile Include="EtwTraceSession.cpp" />
     <ClCompile Include="HidHideDiagnosticsJson.cpp" />
-    <ClCompile Include="Main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="App.hpp" />

--- a/Watchdog/Watchdog.vcxproj
+++ b/Watchdog/Watchdog.vcxproj
@@ -346,8 +346,6 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>HIDHIDE_WATCHDOG_HTTP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <!-- std::expected (neflib), std::format (Win32Error): requires ISO C++23 -->
-      <AdditionalOptions>/std:c++23 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Watchdog/Watchdog.vcxproj
+++ b/Watchdog/Watchdog.vcxproj
@@ -345,6 +345,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>HIDHIDE_WATCHDOG_HTTP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- std::expected (neflib), std::format (Win32Error): requires ISO C++23 -->
+      <AdditionalOptions>/std:c++23 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Watchdog/Watchdog.vcxproj
+++ b/Watchdog/Watchdog.vcxproj
@@ -311,12 +311,21 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="App.cpp" />
+    <ClCompile Include="DiagnosticsTraceHandler.cpp" />
+    <ClCompile Include="DiagnosticsTraceService.cpp" />
     <ClCompile Include="ETWUtil.cpp" />
+    <ClCompile Include="EtwTraceSession.cpp" />
+    <ClCompile Include="HidHideDiagnosticsJson.cpp" />
     <ClCompile Include="Main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="App.hpp" />
+    <ClInclude Include="DiagnosticsTraceHandler.hpp" />
+    <ClInclude Include="DiagnosticsTraceService.hpp" />
     <ClInclude Include="ETWUtil.h" />
+    <ClInclude Include="EtwTraceSession.hpp" />
+    <ClInclude Include="HidHideDiagnosticsJson.hpp" />
+    <ClInclude Include="HidHideDiagnosticsTypes.hpp" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="resource1.h" />
   </ItemGroup>
@@ -333,6 +342,11 @@
   <ItemGroup>
     <Image Include="favicon.ico" />
   </ItemGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>HIDHIDE_WATCHDOG_HTTP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Watchdog/Watchdog.vcxproj
+++ b/Watchdog/Watchdog.vcxproj
@@ -135,6 +135,12 @@
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
   </PropertyGroup>
+  <PropertyGroup Label="WatchdogHttp">
+    <!-- Opt out with msbuild /p:EnableWatchdogHttp=false to omit HIDHIDE_WATCHDOG_HTTP (see App.cpp). -->
+    <EnableWatchdogHttp Condition="'$(EnableWatchdogHttp)'==''">true</EnableWatchdogHttp>
+    <WatchdogHttpPreprocessor Condition="'$(EnableWatchdogHttp)'=='true'">HIDHIDE_WATCHDOG_HTTP;</WatchdogHttpPreprocessor>
+    <WatchdogHttpPreprocessor Condition="'$(EnableWatchdogHttp)'!='true'"></WatchdogHttpPreprocessor>
+  </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <VcpkgUseStatic>true</VcpkgUseStatic>
   </PropertyGroup>
@@ -345,7 +351,7 @@
   </ItemGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>HIDHIDE_WATCHDOG_HTTP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>$(WatchdogHttpPreprocessor)%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Watchdog/vcpkg.json
+++ b/Watchdog/vcpkg.json
@@ -15,6 +15,7 @@
     },
     "spdlog",
     "winreg",
+    "wil",
     "neflib",
     "scope-guard"
   ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local diagnostics HTTP API to query status, start/stop recordings, download ETL captures (streamed with suggested filename), and discard captures.
  * Selectable trace scope (full/driver/userspace), optional channel visibility tuning, and preset visibility modes.
  * Diagnostics server now announces itself on http://127.0.0.1:34501 when enabled.
  * Persistent ETL output handling with unique filenames and download support.

* **Chores**
  * Build, include and dependency consolidation to support diagnostics functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->