### PR TITLE
Prevent crash when enumerating a device in broken state

### DIFF
--- a/HidHideCLI/src/HID.cpp
+++ b/HidHideCLI/src/HID.cpp
@@ -292,7 +292,12 @@ namespace
 
         // Prepare for device interactions
         PHIDP_PREPARSED_DATA preParsedData;
-        if (FALSE == ::HidD_GetPreparsedData(deviceObject.get(), &preParsedData)) THROW_WIN32_LAST_ERROR;
+        if (FALSE == ::HidD_GetPreparsedData(deviceObject.get(), &preParsedData))
+        {
+            if (ERROR_DEVICE_NOT_CONNECTED != ::GetLastError()) THROW_WIN32_LAST_ERROR;
+            return (result);
+        }
+
         auto const freePreparsedDataPtr{ HidD_FreePreparsedDataPtr(preParsedData, &::HidD_FreePreparsedData) };
 
         // Get the usage page


### PR DESCRIPTION
Fix a crash on the GUI client I got when enumerating a virtual device that was behaving weirdly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced device disconnect resilience. The application now gracefully handles situations where devices become unavailable during operation, continuing with available information instead of aborting completely. This improvement enhances system stability and user experience when working with unreliable hardware or temporarily disconnected peripherals, significantly minimizing unexpected failures and improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->