### PR TITLE
Fixing Xbox360/XUSB hiding via config GUI

### DIFF
--- a/HidHideCLI/src/Commands.cpp
+++ b/HidHideCLI/src/Commands.cpp
@@ -50,6 +50,7 @@ namespace
             << L"\"usage\" : \"" << escape_json(hidDeviceInformation.usage) << L"\" ," << std::endl \
             << L"\"description\" : \"" << escape_json(hidDeviceInformation.description) << L"\" ," << std::endl \
             << L"\"deviceInstancePath\" : \"" << escape_json(hidDeviceInformation.deviceInstancePath) << L"\" ," << std::endl \
+            << L"\"xusbDeviceInstancePath\" : \"" << escape_json(hidDeviceInformation.xusbDeviceInstancePath) << L"\" ," << std::endl \
             << L"\"baseContainerDeviceInstancePath\" : \"" << escape_json(hidDeviceInformation.baseContainerDeviceInstancePath) << L"\" ," << std::endl \
             << L"\"baseContainerClassGuid\" : \"" << escape_json(HidHide::GuidToString(hidDeviceInformation.baseContainerClassGuid)) << L"\" ," << std::endl \
             << L"\"baseContainerDeviceCount\" : " << hidDeviceInformation.baseContainerDeviceCount << L" }";

--- a/HidHideCLI/src/HID.cpp
+++ b/HidHideCLI/src/HID.cpp
@@ -207,8 +207,9 @@ namespace
 
         if (auto const result{ ::CM_Locate_DevNodeW(&devInst, const_cast<DEVINSTID_W>(deviceInstancePath.c_str()), CM_LOCATE_DEVNODE_PHANTOM) }; (CR_SUCCESS != result)) return {};
 
-        if (auto const result{ ::CM_Get_Parent(&devInstParent, devInst, 0) }; (CR_NO_SUCH_DEVNODE == result)) return {};
-        if (CR_SUCCESS != result) return {};
+        auto const parentResult{ ::CM_Get_Parent(&devInstParent, devInst, 0) };
+        if (CR_NO_SUCH_DEVNODE == parentResult) return {};
+        if (CR_SUCCESS != parentResult) return {};
 
         needed = static_cast<ULONG>(buffer.size());
         if (auto const result{ ::CM_Get_DevNode_PropertyW(devInstParent, &DEVPKEY_Device_InstanceId, &devPropType, reinterpret_cast<PBYTE>(buffer.data()), &needed, 0) }; (CR_SUCCESS != result)) return {};

--- a/HidHideCLI/src/HID.cpp
+++ b/HidHideCLI/src/HID.cpp
@@ -194,6 +194,57 @@ namespace
         return (buffer.data());
     }
 
+    // Parent device instance path, or empty when there is no parent or on lookup failure (non-throwing; for walking to the root)
+    DeviceInstancePath DeviceInstancePathParentOptional(_In_ DeviceInstancePath const& deviceInstancePath)
+    {
+        if (deviceInstancePath.empty()) return {};
+
+        DEVINST            devInst{};
+        DEVINST            devInstParent{};
+        DEVPROPTYPE        devPropType{};
+        std::vector<WCHAR> buffer(UNICODE_STRING_MAX_CHARS);
+        ULONG              needed{ static_cast<ULONG>(buffer.size()) };
+
+        if (auto const result{ ::CM_Locate_DevNodeW(&devInst, const_cast<DEVINSTID_W>(deviceInstancePath.c_str()), CM_LOCATE_DEVNODE_PHANTOM) }; (CR_SUCCESS != result)) return {};
+
+        if (auto const result{ ::CM_Get_Parent(&devInstParent, devInst, 0) }; (CR_NO_SUCH_DEVNODE == result)) return {};
+        if (CR_SUCCESS != result) return {};
+
+        needed = static_cast<ULONG>(buffer.size());
+        if (auto const result{ ::CM_Get_DevNode_PropertyW(devInstParent, &DEVPKEY_Device_InstanceId, &devPropType, reinterpret_cast<PBYTE>(buffer.data()), &needed, 0) }; (CR_SUCCESS != result)) return {};
+        if (DEVPROP_TYPE_EMPTY == devPropType) return {};
+        if (DEVPROP_TYPE_STRING != devPropType) return {};
+        return (buffer.data());
+    }
+
+    // True when SetupAPI reports at least one registered device interface on this devnode (non-throwing)
+    bool DeviceInstancePathHasDeviceInterface(_In_ GUID const& deviceInterfaceGuid, _In_ DeviceInstancePath const& deviceInstancePath)
+    {
+        auto const rawHandle{ ::SetupDiGetClassDevsW(&deviceInterfaceGuid, deviceInstancePath.c_str(), nullptr, DIGCF_DEVICEINTERFACE) };
+        if (INVALID_HANDLE_VALUE == rawHandle) return (false);
+        auto const handle{ SetupDiDestroyDeviceInfoListPtr(rawHandle, &::SetupDiDestroyDeviceInfoList) };
+
+        SP_DEVICE_INTERFACE_DATA deviceInterfaceData{};
+        deviceInterfaceData.cbSize = sizeof(deviceInterfaceData);
+        if (FALSE == ::SetupDiEnumDeviceInterfaces(handle.get(), nullptr, &deviceInterfaceGuid, 0, &deviceInterfaceData))
+        {
+            if (ERROR_NO_MORE_ITEMS != ::GetLastError()) return (false);
+            return (false);
+        }
+        return (true);
+    }
+
+    // Nearest ancestor (including leaf) whose devnode exposes the given device interface (e.g. GUID_DEVINTERFACE_XUSB for XInput)
+    DeviceInstancePath FindAncestorWithDeviceInterface(_In_ DeviceInstancePath const& leaf, _In_ GUID const& deviceInterfaceGuid)
+    {
+        TRACE_ALWAYS(L"");
+        for (auto current{ leaf }; !current.empty(); current = DeviceInstancePathParentOptional(current))
+        {
+            if (DeviceInstancePathHasDeviceInterface(deviceInterfaceGuid, current)) return (current);
+        }
+        return {};
+    }
+
     // When a device has a base container id then get the device instance path of the base container id
     // Returns an empty string when the device doesn't have a base container id
     DeviceInstancePath BaseContainerDeviceInstancePath(_In_ DeviceInstancePath const& deviceInstancePath)
@@ -258,6 +309,7 @@ namespace
         result.symbolicLink                    = symbolicLink;
         result.description                     = DeviceDescription(deviceInstancePath);
         result.deviceInstancePath              = deviceInstancePath;
+        result.xusbDeviceInstancePath          = FindAncestorWithDeviceInterface(deviceInstancePath, GUID_DEVINTERFACE_XUSB);
         result.baseContainerDeviceInstancePath = BaseContainerDeviceInstancePath(deviceInstancePath);
         result.baseContainerClassGuid          = DeviceClassGuid(result.baseContainerDeviceInstancePath);
         result.baseContainerDeviceCount        = BaseContainerDeviceCount(result.baseContainerDeviceInstancePath);

--- a/HidHideCLI/src/HID.h
+++ b/HidHideCLI/src/HID.h
@@ -18,6 +18,7 @@ namespace HidHide
         std::wstring          usage;
         std::wstring          description;
         DeviceInstancePath    deviceInstancePath;
+        DeviceInstancePath    xusbDeviceInstancePath;
         DeviceInstancePath    baseContainerDeviceInstancePath;
         GUID                  baseContainerClassGuid;
         size_t                baseContainerDeviceCount;

--- a/HidHideClient/src/BlacklistDlg.cpp
+++ b/HidHideClient/src/BlacklistDlg.cpp
@@ -177,9 +177,14 @@ LRESULT CBlacklistDlg::OnUserMessageRefresh(WPARAM wParam, LPARAM lParam)
     {
         // Get the device instance path of its base container id (if present)
         auto const baseContainerDeviceInstancePath{ (topLevelEntry.second.empty() ? L"" : topLevelEntry.second.at(0).baseContainerDeviceInstancePath) };
+        auto const xusbDeviceInstancePath{ (topLevelEntry.second.empty() ? L"" : topLevelEntry.second.at(0).xusbDeviceInstancePath) };
 
         // Is the top-level entry on the black-list ?
-        auto const topLevelEntryBlacklisted{ std::end(deviceInstancePathsBlacklisted) != std::find(std::begin(deviceInstancePathsBlacklisted), std::end(deviceInstancePathsBlacklisted), baseContainerDeviceInstancePath) };
+        auto const topLevelEntryBlacklisted
+        {
+            (std::end(deviceInstancePathsBlacklisted) != std::find(std::begin(deviceInstancePathsBlacklisted), std::end(deviceInstancePathsBlacklisted), baseContainerDeviceInstancePath))
+            || ((!xusbDeviceInstancePath.empty()) && (std::end(deviceInstancePathsBlacklisted) != std::find(std::begin(deviceInstancePathsBlacklisted), std::end(deviceInstancePathsBlacklisted), xusbDeviceInstancePath)))
+        };
 
         // Is any of the child entries on the black-list ?
         auto const anyChildEntryBlacklisted{ std::end(topLevelEntry.second) != std::find_if(std::begin(topLevelEntry.second), std::end(topLevelEntry.second), [&deviceInstancePathsBlacklisted](HidHide::HidDeviceInformation const& value)
@@ -300,12 +305,13 @@ void CBlacklistDlg::OnTvnItemChangedTreeBlacklist(NMHDR* pNMHDR, LRESULT* pResul
         {
             // Get the base container device details (just take it from any of the child devices)
             // Note that the class guid will be GUID_NULL when this is a stand-alone device
-            std::wstring baseContainerDeviceInstancePath;
-            GUID         baseContainerClassGuid{};
-            size_t       baseContainerDeviceCount{};
+            std::wstring                         baseContainerDeviceInstancePath;
+            GUID                                 baseContainerClassGuid{};
+            size_t                               baseContainerDeviceCount{};
+            HidHide::HidDeviceInformation const* firstChilditemData{};
             if (auto const hFirstChild{ m_Blacklist.GetChildItem(hItem) }; (nullptr != hFirstChild))
             {
-                auto const firstChilditemData{ reinterpret_cast<HidHide::HidDeviceInformation*>(m_Blacklist.GetItemData(hFirstChild)) };
+                firstChilditemData = reinterpret_cast<HidHide::HidDeviceInformation*>(m_Blacklist.GetItemData(hFirstChild));
                 if (nullptr == firstChilditemData) THROW_WIN32(ERROR_INVALID_PARAMETER);
                 baseContainerDeviceInstancePath = firstChilditemData->baseContainerDeviceInstancePath;
                 baseContainerClassGuid          = firstChilditemData->baseContainerClassGuid;
@@ -327,6 +333,12 @@ void CBlacklistDlg::OnTvnItemChangedTreeBlacklist(NMHDR* pNMHDR, LRESULT* pResul
             {
                 deviceInstancePaths.emplace(baseContainerDeviceInstancePath);
             }
+
+            // XInput opens GUID_DEVINTERFACE_XUSB; hide that devnode whenever the whole group is selected from the parent row
+            if ((nullptr != firstChilditemData) && (!firstChilditemData->xusbDeviceInstancePath.empty()))
+            {
+                deviceInstancePaths.emplace(firstChilditemData->xusbDeviceInstancePath);
+            }
         }
 
         // Block the individual child devices
@@ -337,6 +349,10 @@ void CBlacklistDlg::OnTvnItemChangedTreeBlacklist(NMHDR* pNMHDR, LRESULT* pResul
                 auto const childItemData{ reinterpret_cast<HidHide::HidDeviceInformation*>(m_Blacklist.GetItemData(hChild)) };
                 if (nullptr == childItemData) THROW_WIN32(ERROR_INVALID_PARAMETER);
                 deviceInstancePaths.emplace(childItemData->deviceInstancePath);
+                if (!childItemData->xusbDeviceInstancePath.empty())
+                {
+                    deviceInstancePaths.emplace(childItemData->xusbDeviceInstancePath);
+                }
             }
         }
     }

--- a/HidHideClient/src/BlacklistDlg.cpp
+++ b/HidHideClient/src/BlacklistDlg.cpp
@@ -177,13 +177,15 @@ LRESULT CBlacklistDlg::OnUserMessageRefresh(WPARAM wParam, LPARAM lParam)
     {
         // Get the device instance path of its base container id (if present)
         auto const baseContainerDeviceInstancePath{ (topLevelEntry.second.empty() ? L"" : topLevelEntry.second.at(0).baseContainerDeviceInstancePath) };
-        auto const xusbDeviceInstancePath{ (topLevelEntry.second.empty() ? L"" : topLevelEntry.second.at(0).xusbDeviceInstancePath) };
 
         // Is the top-level entry on the black-list ?
         auto const topLevelEntryBlacklisted
         {
             (std::end(deviceInstancePathsBlacklisted) != std::find(std::begin(deviceInstancePathsBlacklisted), std::end(deviceInstancePathsBlacklisted), baseContainerDeviceInstancePath))
-            || ((!xusbDeviceInstancePath.empty()) && (std::end(deviceInstancePathsBlacklisted) != std::find(std::begin(deviceInstancePathsBlacklisted), std::end(deviceInstancePathsBlacklisted), xusbDeviceInstancePath)))
+            || std::any_of(std::begin(topLevelEntry.second), std::end(topLevelEntry.second), [&deviceInstancePathsBlacklisted](HidHide::HidDeviceInformation const& value)
+            {
+                return ((!value.xusbDeviceInstancePath.empty()) && (std::end(deviceInstancePathsBlacklisted) != std::find(std::begin(deviceInstancePathsBlacklisted), std::end(deviceInstancePathsBlacklisted), value.xusbDeviceInstancePath)));
+            })
         };
 
         // Is any of the child entries on the black-list ?


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blacklist now supports XUSB device instance paths so XUSB controllers can be filtered like other devices.
  * Device info exposed an additional XUSB device identifier, improving discovery and making blacklist decisions more accurate in the UI and driver updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/HidHide/pull/210)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->