### PR TITLE
Fix buffer size calculation in `HidHideCollectionToMultiString` and vector allocation

### DIFF
--- a/HidHide/src/Config.c
+++ b/HidHide/src/Config.c
@@ -753,7 +753,7 @@ NTSTATUS HidHideCollectionToMultiString(WDFCOLLECTION wdfCollection, LPWSTR buff
     for (ULONG index = 0, size = WdfCollectionGetCount(wdfCollection); (index < size); index++)
     {
         WdfStringGetUnicodeString(WdfCollectionGetItem(wdfCollection, index), &string); // PASSIVE_LEVEL
-        (*neededSizeInCharacters) += string.Length;
+        (*neededSizeInCharacters) += (string.Length / sizeof(WCHAR));
         (*neededSizeInCharacters)++;
     }
     // Don't overlook the multi-string terminator

--- a/HidHideCLI/src/FilterDriverProxy.cpp
+++ b/HidHideCLI/src/FilterDriverProxy.cpp
@@ -67,7 +67,7 @@ namespace
         TRACE_ALWAYS(L"");
         DWORD needed{};
         if (FALSE == ::DeviceIoControl(device, IOCTL_GET_BLACKLIST, nullptr, 0, nullptr, 0, &needed, nullptr)) THROW_WIN32_LAST_ERROR;
-        auto buffer{ std::vector<WCHAR>(needed) };
+        auto buffer{ std::vector<WCHAR>(needed / sizeof(WCHAR)) };
         if (FALSE == ::DeviceIoControl(device, IOCTL_GET_BLACKLIST, nullptr, 0, buffer.data(), static_cast<DWORD>(buffer.size() * sizeof(WCHAR)), &needed, nullptr)) THROW_WIN32_LAST_ERROR;
         return (HidHide::StringListToStringSet(HidHide::MultiStringToStringList(buffer)));
     }
@@ -87,7 +87,7 @@ namespace
         TRACE_ALWAYS(L"");
         DWORD needed{};
         if (FALSE == ::DeviceIoControl(device, IOCTL_GET_WHITELIST, nullptr, 0, nullptr, 0, &needed, nullptr)) THROW_WIN32_LAST_ERROR;
-        auto buffer{ std::vector<WCHAR>(needed) };
+        auto buffer{ std::vector<WCHAR>(needed / sizeof(WCHAR)) };
         if (FALSE == ::DeviceIoControl(device, IOCTL_GET_WHITELIST, nullptr, 0, buffer.data(), static_cast<DWORD>(buffer.size() * sizeof(WCHAR)), &needed, nullptr)) THROW_WIN32_LAST_ERROR;
         return (HidHide::StringListToPathSet(HidHide::MultiStringToStringList(buffer)));
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed buffer size calculations in device configuration and filter driver communication to ensure proper data handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/HidHide/pull/211)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->